### PR TITLE
PR: R4 format support — EncodingLayout and field-to-bit mapping #17

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -91,6 +91,9 @@ verify_sim() {
     echo "=== spike simulation (sample fixture) ==="
     EV_SIM_BACKEND=spike EV_PK_PATH="${EV_PK_PATH:-pk}" \
         "$EV" simulate --target "$MIXED" 2>&1 || true
+    echo "=== spike simulation (cva6 xif ref r4) ==="
+    EV_SIM_BACKEND=spike EV_PK_PATH="${EV_PK_PATH:-pk}" \
+        "$EV" simulate --target "tests/fixtures/cva6_xif_ref_r4.xif.yaml" 2>&1 || true
 }
 
 verify_fixtures() {

--- a/run.sh
+++ b/run.sh
@@ -105,7 +105,9 @@ verify_fixtures() {
         exit 1
     fi
     echo "=== json output ==="
-    echo "  $($EV verify --target "$MIXED" --json 2>/dev/null | python3 -c 'import sys,json;d=json.load(sys.stdin);p=json.loads(bytes(d["payload"]).decode());print(f"Total: {p["total"]}, Passed: {p["passed"]}, Failed: {p["failed"]}")' 2>/dev/null || echo 'parse error')"
+    local json_out
+    json_out=$($EV verify --target "$MIXED" --json 2>/dev/null || true)
+    echo "  $(echo "$json_out" | python3 -c 'import sys,json;d=json.load(sys.stdin);p=json.loads(bytes(d["payload"]).decode());print(f"Total: {p["total"]}, Passed: {p["passed"]}, Failed: {p["failed"]}")' 2>/dev/null || echo 'parse error')"
 }
 
 # ── Modes ─────────────────────────────────────────────────────────────

--- a/run.sh
+++ b/run.sh
@@ -146,6 +146,8 @@ case ${1:-} in
         verify_fixtures
         echo "=== cva6 xif ref fixture (33M combos, text output) ==="
         EC=0; $EV verify --target "tests/fixtures/cva6_xif_ref.xif.yaml" 2>&1 | tail -4
+        echo "=== cva6 xif ref r4 fixture (262k combos, func2) ==="
+        EC=0; $EV verify --target "tests/fixtures/cva6_xif_ref_r4.xif.yaml" 2>&1 | tail -4
         verify_sim
         echo "=== cva6 xif encoding-only spike sim ==="
         EV_SIM_BACKEND=spike EV_PK_PATH="${EV_PK_PATH:-pk}" \

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -135,6 +135,7 @@ mod tests {
         VerificationSpec {
             target: "test".into(),
             fields,
+            encoding: None,
             constraints: vec![],
             projector: crate::spec::ProjectorSpec::Sum,
         }

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -121,6 +121,7 @@ mod tests {
             fields,
             constraints,
             projector,
+            encoding: None,
         }
     }
 

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -254,6 +254,7 @@ mod tests {
         VerificationSpec {
             target: "test".into(),
             fields,
+            encoding: None,
             constraints: vec![ConstraintSpec::Eq {
                 field_a: "op".into(),
                 field_b: "rs1".into(),

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -4,6 +4,35 @@
 use serde::Deserialize;
 use std::collections::BTreeMap;
 
+/// Describes how instruction fields map to bits in the encoded instruction word.
+///
+/// Each entry maps a field name to its bit position (0 = LSB) and width.
+/// This is format-agnostic: R-type, R4, I-type, S-type, etc. are all
+/// just different field-to-bit mappings.
+#[derive(Debug, Clone, Deserialize)]
+pub struct EncodingLayout {
+    /// Total width in bits (typically 32 for RISC-V).
+    #[serde(default = "default_insn_width")]
+    pub insn_width: u32,
+    /// Field-to-bit mapping: field_name -> (bit_position, bit_width).
+    #[serde(default)]
+    pub field_map: BTreeMap<String, FieldBitMapping>,
+}
+
+fn default_insn_width() -> u32 {
+    32
+}
+
+/// Bit position and width for a single field in the instruction word.
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub struct FieldBitMapping {
+    /// Bit position (0 = LSB).
+    #[serde(default)]
+    pub pos: u32,
+    /// Bit width.
+    pub width: u32,
+}
+
 /// Unified internal representation of a verification target.
 ///
 /// All input formats (YAML, JSON, .ss) parse into this struct. The pipeline
@@ -14,6 +43,8 @@ pub struct VerificationSpec {
     pub target: String,
     /// Ordered field definitions (deterministic: BTreeMap iteration order).
     pub fields: BTreeMap<String, FieldSpec>,
+    /// Instruction word encoding layout (field -> bit position/width).
+    pub encoding: Option<EncodingLayout>,
     /// Named constraint specifications to resolve via ConstraintRegistry.
     pub constraints: Vec<ConstraintSpec>,
     /// Named projector specification to resolve via ProjectorRegistry.

--- a/src/synth/backends/spike.rs
+++ b/src/synth/backends/spike.rs
@@ -87,7 +87,13 @@ impl RunSimulation for SpikeBackend {
         // Generate C source with signal handling and per-encoding execution.
         let tmp_dir = std::env::temp_dir().join("ev-sim");
         std::fs::create_dir_all(&tmp_dir)?;
-        let c_src = generate_c_source(&spec.target, &spec.encoding, &field_names, &spec.constraints, &valid_rows);
+        let c_src = generate_c_source(
+            &spec.target,
+            &spec.encoding,
+            &field_names,
+            &spec.constraints,
+            &valid_rows,
+        );
         let c_file_name = format!("ev_sim_{}.c", spec.target.replace(char::is_whitespace, "_"));
         let c_path = tmp_dir.join(&c_file_name);
         std::fs::write(&c_path, c_src)?;
@@ -205,19 +211,30 @@ fn generate_c_source(
     let constraint_code = generate_c_constraints(constraints, field_names);
 
     // Generate instruction word assembly code from encoding layout.
-    // Produces C code like:  word |= (enc[IDX_rs1] & 0x1F) << 15;
+    // Fields in the layout that are absent from the spec's field list
+    // (e.g. a fixed `opcode` field) use constant 0, since they are not
+    // part of the combinatorial expansion.
     let assemble_lines: Vec<String> = match encoding_opt {
         Some(layout) => layout
             .field_map
             .iter()
             .map(|(name, mapping)| {
                 let mask = (1u64 << mapping.width) - 1;
-                format!(
-                    "    word |= (uint64_t)(enc[IDX_{name}] & 0x{mask:X}ULL) << {pos};",
-                    name = name,
-                    mask = mask,
-                    pos = mapping.pos
-                )
+                let has_idx = field_names.contains(&name);
+                if has_idx {
+                    format!(
+                        "    word |= (uint64_t)(enc[IDX_{name}] & 0x{mask:X}ULL) << {pos};",
+                        name = name,
+                        mask = mask,
+                        pos = mapping.pos
+                    )
+                } else {
+                    format!(
+                        "    word |= (uint64_t)(0 & 0x{mask:X}ULL) << {pos};",
+                        mask = mask,
+                        pos = mapping.pos
+                    )
+                }
             })
             .collect(),
         None => vec![],

--- a/src/synth/backends/spike.rs
+++ b/src/synth/backends/spike.rs
@@ -168,26 +168,11 @@ fn merge_results_with_indices(
 // C source generation
 // ============================================================================
 
-<<<<<<< HEAD
-/// Generate C source that performs static constraint verification.
-///
-/// This C harness mirrors ev's static evaluation (field range/cross-field
-/// constraints) and runs it under Spike to confirm that the cross-compiled
-/// C code produces the same results as ev's Rust evaluator.
-///
-/// Actual instruction-word execution under Spike is not possible with stock
-/// pk, because pk terminates the process on illegal instruction traps
-/// instead of delivering SIGILL to the process. To test actual instruction
-/// execution, a Spike extension plugin (e.g., CVA6 cvxif) is required.
-fn generate_c_source(
-    target: &str,
-=======
 /// Generate C source with packed encoding data, constraint evaluation,
 /// and instruction word assembly from encoding layout.
 fn generate_c_source(
     target: &str,
     encoding_opt: &Option<EncodingLayout>,
->>>>>>> 92df39e (feat: integrate EncodingLayout into Spike C harness with instruction word assembly #17)
     field_names: &[&String],
     constraints: &[ConstraintSpec],
     rows: &[Vec<i64>],
@@ -321,14 +306,9 @@ int main(void) {{
     uint64_t pass = 0, fail = 0;
     for (uint64_t i = 0; i < NUM_ENCODINGS; i++) {{
         int ok = check_encoding(ENCODINGS[i]);
-<<<<<<< HEAD
-        printf("ENC:%llu:%d\n", (unsigned long long)i, ok);
-        if (ok) {{ pass++; }} else {{ fail++; }}
-=======
         uint64_t instr = assemble_instr(ENCODINGS[i]);
         if (ok) {{ pass++; }} else {{ fail++; }}
         printf("ENC:%llu:%d:0x%016llX\n", (unsigned long long)i, ok, (unsigned long long)instr);
->>>>>>> 92df39e (feat: integrate EncodingLayout into Spike C harness with instruction word assembly #17)
     }}
     printf("PASSED:%llu\n", (unsigned long long)pass);
     printf("FAILED:%llu\n", (unsigned long long)fail);
@@ -341,11 +321,8 @@ int main(void) {{
         data = data_lines.join(",\n"),
         field_indexes = field_indexes.join("\n"),
         constraint_code = constraint_code,
-<<<<<<< HEAD
-=======
         instr_word_array = instr_word_array,
         assemble_code = assemble_code,
->>>>>>> 92df39e (feat: integrate EncodingLayout into Spike C harness with instruction word assembly #17)
     )
 }
 

--- a/src/synth/backends/spike.rs
+++ b/src/synth/backends/spike.rs
@@ -35,7 +35,7 @@
 //! * `EV_RISCV_CC` — RISC-V cross-compiler (default: "riscv64-unknown-elf-gcc")
 
 use crate::evaluate::Evaluation;
-use crate::spec::{ConstraintSpec, VerificationSpec};
+use crate::spec::{ConstraintSpec, EncodingLayout, VerificationSpec};
 use crate::synth::sim::{RunSimulation, SimulationResult};
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -87,7 +87,7 @@ impl RunSimulation for SpikeBackend {
         // Generate C source with signal handling and per-encoding execution.
         let tmp_dir = std::env::temp_dir().join("ev-sim");
         std::fs::create_dir_all(&tmp_dir)?;
-        let c_src = generate_c_source(&spec.target, &field_names, &spec.constraints, &valid_rows);
+        let c_src = generate_c_source(&spec.target, &spec.encoding, &field_names, &spec.constraints, &valid_rows);
         let c_file_name = format!("ev_sim_{}.c", spec.target.replace(char::is_whitespace, "_"));
         let c_path = tmp_dir.join(&c_file_name);
         std::fs::write(&c_path, c_src)?;
@@ -168,6 +168,7 @@ fn merge_results_with_indices(
 // C source generation
 // ============================================================================
 
+<<<<<<< HEAD
 /// Generate C source that performs static constraint verification.
 ///
 /// This C harness mirrors ev's static evaluation (field range/cross-field
@@ -180,6 +181,13 @@ fn merge_results_with_indices(
 /// execution, a Spike extension plugin (e.g., CVA6 cvxif) is required.
 fn generate_c_source(
     target: &str,
+=======
+/// Generate C source with packed encoding data, constraint evaluation,
+/// and instruction word assembly from encoding layout.
+fn generate_c_source(
+    target: &str,
+    encoding_opt: &Option<EncodingLayout>,
+>>>>>>> 92df39e (feat: integrate EncodingLayout into Spike C harness with instruction word assembly #17)
     field_names: &[&String],
     constraints: &[ConstraintSpec],
     rows: &[Vec<i64>],
@@ -211,6 +219,69 @@ fn generate_c_source(
     // Generate constraint check code.
     let constraint_code = generate_c_constraints(constraints, field_names);
 
+    // Generate instruction word assembly code from encoding layout.
+    // Produces C code like:  word |= (enc[IDX_rs1] & 0x1F) << 15;
+    let assemble_lines: Vec<String> = match encoding_opt {
+        Some(layout) => layout
+            .field_map
+            .iter()
+            .map(|(name, mapping)| {
+                let mask = (1u64 << mapping.width) - 1;
+                format!(
+                    "    word |= (uint64_t)(enc[IDX_{name}] & 0x{mask:X}ULL) << {pos};",
+                    name = name,
+                    mask = mask,
+                    pos = mapping.pos
+                )
+            })
+            .collect(),
+        None => vec![],
+    };
+    let assemble_code = if assemble_lines.is_empty() {
+        "    (void)word;".into()
+    } else {
+        assemble_lines.join("\n")
+    };
+
+    // Generate pre-computed instruction words for each encoding.
+    let instr_word_lines: Vec<String> = match encoding_opt {
+        Some(layout) => rows
+            .iter()
+            .map(|row| {
+                let mut word: u64 = 0;
+                for (name, mapping) in &layout.field_map {
+                    if let Some(idx) = field_names.iter().position(|n| *n == name) {
+                        let val = row[idx] as u64;
+                        let mask = (1u64 << mapping.width) - 1;
+                        word |= (val & mask) << mapping.pos;
+                    }
+                }
+                // Truncate to insn_width bits
+                let mask = if layout.insn_width < 64 {
+                    (1u64 << layout.insn_width) - 1
+                } else {
+                    !0u64
+                };
+                format!("    0x{:016X}ULL", word & mask)
+            })
+            .collect(),
+        None => vec![],
+    };
+    let instr_word_data = if instr_word_lines.is_empty() {
+        String::new()
+    } else {
+        instr_word_lines.join(",\n")
+    };
+    let instr_word_array = if !instr_word_lines.is_empty() {
+        format!(
+            "\n/* Pre-assembled instruction words from encoding layout */\nstatic const uint64_t INSTR_WORDS[{nenc}] = {{\n{data}\n}};\n",
+            nenc = num_encodings,
+            data = instr_word_data
+        )
+    } else {
+        String::new()
+    };
+
     format!(
         r#"#include <stdio.h>
 #include <stdlib.h>
@@ -230,6 +301,7 @@ static void init(void) {{ setbuf(stdout, NULL); setbuf(stderr, NULL); }}
 static const int64_t ENCODINGS[{nenc}][{nfields}] = {{
 {data}
 }};
+{instr_word_array}
 
 const uint64_t NUM_ENCODINGS = {nenc};
 const uint64_t NUM_FIELDS = {nfields};
@@ -239,12 +311,24 @@ static int check_encoding(const int64_t enc[]) {{
 {constraint_code}
 }}
 
+static uint64_t assemble_instr(const int64_t enc[]) {{
+    uint64_t word = 0;
+{assemble_code}
+    return word;
+}}
+
 int main(void) {{
     uint64_t pass = 0, fail = 0;
     for (uint64_t i = 0; i < NUM_ENCODINGS; i++) {{
         int ok = check_encoding(ENCODINGS[i]);
+<<<<<<< HEAD
         printf("ENC:%llu:%d\n", (unsigned long long)i, ok);
         if (ok) {{ pass++; }} else {{ fail++; }}
+=======
+        uint64_t instr = assemble_instr(ENCODINGS[i]);
+        if (ok) {{ pass++; }} else {{ fail++; }}
+        printf("ENC:%llu:%d:0x%016llX\n", (unsigned long long)i, ok, (unsigned long long)instr);
+>>>>>>> 92df39e (feat: integrate EncodingLayout into Spike C harness with instruction word assembly #17)
     }}
     printf("PASSED:%llu\n", (unsigned long long)pass);
     printf("FAILED:%llu\n", (unsigned long long)fail);
@@ -257,6 +341,11 @@ int main(void) {{
         data = data_lines.join(",\n"),
         field_indexes = field_indexes.join("\n"),
         constraint_code = constraint_code,
+<<<<<<< HEAD
+=======
+        instr_word_array = instr_word_array,
+        assemble_code = assemble_code,
+>>>>>>> 92df39e (feat: integrate EncodingLayout into Spike C harness with instruction word assembly #17)
     )
 }
 

--- a/src/synth/mod.rs
+++ b/src/synth/mod.rs
@@ -343,6 +343,7 @@ mod tests {
         VerificationSpec {
             target: "test_module".into(),
             fields,
+            encoding: None,
             constraints: vec![],
             projector,
         }

--- a/src/xif.rs
+++ b/src/xif.rs
@@ -4,7 +4,9 @@
 //! existing RISC-V verification workflows (RISCV-CTG, RISCV-DV, RISCV-Config).
 
 use crate::format::FormatCapable;
-use crate::spec::{ConstraintSpec, EncodingLayout, FieldBitMapping, FieldSpec, ProjectorSpec, VerificationSpec};
+use crate::spec::{
+    ConstraintSpec, EncodingLayout, FieldBitMapping, FieldSpec, ProjectorSpec, VerificationSpec,
+};
 use anyhow::Context;
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -30,7 +32,10 @@ fn default_rtype_encoding() -> EncodingLayout {
     field_map.insert("rs1".into(), FieldBitMapping { pos: 15, width: 5 });
     field_map.insert("rs2".into(), FieldBitMapping { pos: 20, width: 5 });
     field_map.insert("funct7".into(), FieldBitMapping { pos: 25, width: 7 });
-    EncodingLayout { insn_width: 32, field_map }
+    EncodingLayout {
+        insn_width: 32,
+        field_map,
+    }
 }
 
 /// R4 encoding layout (R-type with func2 replacing funct7 bits).
@@ -43,7 +48,10 @@ fn default_r4_encoding() -> EncodingLayout {
     field_map.insert("rs2".into(), FieldBitMapping { pos: 20, width: 5 });
     field_map.insert("func2".into(), FieldBitMapping { pos: 25, width: 2 });
     field_map.insert("rs3".into(), FieldBitMapping { pos: 27, width: 5 });
-    EncodingLayout { insn_width: 32, field_map }
+    EncodingLayout {
+        insn_width: 32,
+        field_map,
+    }
 }
 
 // ── Raw deserialization structs ──
@@ -116,12 +124,12 @@ impl RawXif {
             .collect();
 
         // Resolve encoding layout: explicit layout > named format > default R-type.
-        let encoding = self.encoding_layout.or_else(|| {
-            match self.encoding.as_deref() {
+        let encoding = self
+            .encoding_layout
+            .or_else(|| match self.encoding.as_deref() {
                 Some("r4") => Some(default_r4_encoding()),
                 _ => Some(default_rtype_encoding()),
-            }
-        });
+            });
 
         VerificationSpec {
             target: self.target,

--- a/src/xif.rs
+++ b/src/xif.rs
@@ -4,7 +4,7 @@
 //! existing RISC-V verification workflows (RISCV-CTG, RISCV-DV, RISCV-Config).
 
 use crate::format::FormatCapable;
-use crate::spec::{ConstraintSpec, FieldSpec, ProjectorSpec, VerificationSpec};
+use crate::spec::{ConstraintSpec, EncodingLayout, FieldBitMapping, FieldSpec, ProjectorSpec, VerificationSpec};
 use anyhow::Context;
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -21,6 +21,31 @@ impl FormatCapable for YamlFormat {
     }
 }
 
+/// Default R-type encoding layout for RISC-V.
+fn default_rtype_encoding() -> EncodingLayout {
+    let mut field_map = BTreeMap::new();
+    field_map.insert("opcode".into(), FieldBitMapping { pos: 0, width: 7 });
+    field_map.insert("rd".into(), FieldBitMapping { pos: 7, width: 5 });
+    field_map.insert("funct3".into(), FieldBitMapping { pos: 12, width: 3 });
+    field_map.insert("rs1".into(), FieldBitMapping { pos: 15, width: 5 });
+    field_map.insert("rs2".into(), FieldBitMapping { pos: 20, width: 5 });
+    field_map.insert("funct7".into(), FieldBitMapping { pos: 25, width: 7 });
+    EncodingLayout { insn_width: 32, field_map }
+}
+
+/// R4 encoding layout (R-type with func2 replacing funct7 bits).
+fn default_r4_encoding() -> EncodingLayout {
+    let mut field_map = BTreeMap::new();
+    field_map.insert("opcode".into(), FieldBitMapping { pos: 0, width: 7 });
+    field_map.insert("rd".into(), FieldBitMapping { pos: 7, width: 5 });
+    field_map.insert("funct3".into(), FieldBitMapping { pos: 12, width: 3 });
+    field_map.insert("rs1".into(), FieldBitMapping { pos: 15, width: 5 });
+    field_map.insert("rs2".into(), FieldBitMapping { pos: 20, width: 5 });
+    field_map.insert("func2".into(), FieldBitMapping { pos: 25, width: 2 });
+    field_map.insert("rs3".into(), FieldBitMapping { pos: 27, width: 5 });
+    EncodingLayout { insn_width: 32, field_map }
+}
+
 // ── Raw deserialization structs ──
 
 #[derive(Debug, Deserialize)]
@@ -29,6 +54,12 @@ struct RawXif {
     target: String,
     #[serde(default)]
     fields: BTreeMap<String, RawField>,
+    /// Encoding format: "r" (default, R-type), "r4" (R4 with func2), "i" (I-type), etc.
+    #[serde(default)]
+    encoding: Option<String>,
+    /// Optional explicit encoding layout. If absent, derived from `encoding` field.
+    #[serde(default)]
+    encoding_layout: Option<EncodingLayout>,
     #[serde(default)]
     constraints: Vec<ConstraintSpec>,
     #[serde(default = "default_projector")]
@@ -84,9 +115,18 @@ impl RawXif {
             })
             .collect();
 
+        // Resolve encoding layout: explicit layout > named format > default R-type.
+        let encoding = self.encoding_layout.or_else(|| {
+            match self.encoding.as_deref() {
+                Some("r4") => Some(default_r4_encoding()),
+                _ => Some(default_rtype_encoding()),
+            }
+        });
+
         VerificationSpec {
             target: self.target,
             fields,
+            encoding,
             constraints: self.constraints,
             projector: self.projector,
         }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -153,6 +153,26 @@ fn verify_cva6_xif_mac_fixture() {
 }
 
 #[test]
+fn verify_cva6_xif_ref_r4_fixture() {
+    let output = Command::new(env!("CARGO_BIN_EXE_ev"))
+        .arg("verify")
+        .arg("--target")
+        .arg("tests/fixtures/cva6_xif_ref_r4.xif.yaml")
+        .arg("--json")
+        .output()
+        .expect("failed to run ev verify on cva6_xif_ref_r4 fixture");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("fact_type"),
+        "cva6_xif_ref_r4 should produce fact output"
+    );
+    assert!(
+        stdout.contains("\"payload\""),
+        "cva6_xif_ref_r4 should contain payload"
+    );
+}
+
+#[test]
 fn synth_text_with_mock_backend() {
     let output = Command::new(env!("CARGO_BIN_EXE_ev"))
         .arg("synth")

--- a/tests/fixtures/cva6_xif_ref.xif.yaml
+++ b/tests/fixtures/cva6_xif_ref.xif.yaml
@@ -6,25 +6,32 @@
 # Full register range (0..31) for exhaustive verification of register field
 # independence across all valid encoding combinations.
 #
-# Custom-3 opcode (0x7B) — R-type encoding (verification suite mapping):
-#   funct3=000: ADD variants  (funct7 sub-decoded)
-#   funct3=001: ADD           (funct7=0 only)
-#   funct3=010: EXC           (funct7=96 = 0b1100000)
-#   funct3=011..111: illegal  (rejected by coprocessor)
+# Custom-3 opcode (0x7B):
+#   funct3=000: ADD variants  (funct7 sub-decoded, R4 for ADD_RS3)
+#   funct3=001: ADD / NOP     (funct7=0 only, NOP has rd=rs1=rs2=0)
+#   funct3=010: EXC           (funct7=96 only)
+#   funct3=011..111: illegal
 #
 # funct7 sub-decoding (funct3=000):
-#   funct7=0b0001000 (8):  ADD_MULTI
-#   funct7=0b0000010 (2):  U_ADD
-#   funct7=0b0000110 (6):  S_ADD
-#   funct7=0b0100000 (32): ADD_RS3 (uses func2=01)
+#   funct7=8  (0b0001000): ADD_MULTI
+#   funct7=2  (0b0000010): U_ADD
+#   funct7=6  (0b0000110): S_ADD
+#   funct7=0  + func2=01 : ADD_RS3 (R4 format, func2 bits [26:25])
 #
-# Verification space:
-#   8 × 128 × 32 × 32 × 32 = 33,554,432 raw combinations (~33M)
+# Note: funct7=32 has been replaced by func2=01 (ADD_RS3 R4 encoding).
+# func2 values: [0, 1, 2, 3] but only func2=1 is valid for ADD_RS3.
+#
+# Verification space (register space sampled to keep combinations manageable):
+#   8 × 128 × 4 × 4 × 4 × 4 = 262,144 raw combinations (safe for all hosts)
 #   oneof: funct3 ∈ {0, 1, 2}
-#   cross: funct3=0 → funct7 ∈ {2, 6, 8, 32}
-#          funct3=1 → funct7 ∈ {0}
-#          funct3=2 → funct7 ∈ {96}
-#   Valid: 4×32×32×32 + 1×32×32×32 + 1×32×32×32 = 196,608 pass
+#   cross (funct3 → funct7):
+#     0: [2, 6, 8]    (ADD_RS3 uses func2, not funct7)
+#     1: [0]
+#     2: [96]
+#   cross (funct3 → func2):
+#     0: func2 ∈ {0, 1, 2, 3}  (ADD_RS3 = func2=1)
+#   Valid: 3×4×4×4×4 + 1×4×4×4 + 1×4×4×4 = 768 + 64 + 64 = 896 pass
+#   Full register range (32×32×32) available with rs1/rs2/rd ∈ [0, 31].
 
 target: cva6_xif_ref
 fields:
@@ -32,12 +39,14 @@ fields:
     range: [0, 7]
   funct7:
     range: [0, 127]
+  func2:
+    range: [0, 3]
   rs1:
-    range: [0, 31]
+    range: [0, 3]
   rs2:
-    range: [0, 31]
+    range: [0, 3]
   rd:
-    range: [0, 31]
+    range: [0, 3]
 constraints:
   - type: oneof
     field: "funct3"
@@ -46,8 +55,13 @@ constraints:
     field_a: "funct3"
     field_b: "funct7"
     mapping:
-      0: [2, 6, 8, 32]
+      0: [2, 6, 8]
       1: [0]
       2: [96]
+  - type: cross
+    field_a: "funct3"
+    field_b: "func2"
+    mapping:
+      0: [0, 1, 2, 3]
 projector:
   type: sum

--- a/tests/fixtures/cva6_xif_ref.xif.yaml
+++ b/tests/fixtures/cva6_xif_ref.xif.yaml
@@ -34,6 +34,7 @@
 #   Full register range (32×32×32) available with rs1/rs2/rd ∈ [0, 31].
 
 target: cva6_xif_ref
+encoding: r4
 fields:
   funct3:
     range: [0, 7]

--- a/tests/fixtures/cva6_xif_ref.xif.yaml
+++ b/tests/fixtures/cva6_xif_ref.xif.yaml
@@ -6,48 +6,38 @@
 # Full register range (0..31) for exhaustive verification of register field
 # independence across all valid encoding combinations.
 #
-# Custom-3 opcode (0x7B):
-#   funct3=000: ADD variants  (funct7 sub-decoded, R4 for ADD_RS3)
-#   funct3=001: ADD / NOP     (funct7=0 only, NOP has rd=rs1=rs2=0)
-#   funct3=010: EXC           (funct7=96 only)
-#   funct3=011..111: illegal
+# Custom-3 opcode (0x7B) — R-type encoding (verification suite mapping):
+#   funct3=000: ADD variants  (funct7 sub-decoded)
+#   funct3=001: ADD           (funct7=0 only)
+#   funct3=010: EXC           (funct7=96 = 0b1100000)
+#   funct3=011..111: illegal  (rejected by coprocessor)
 #
 # funct7 sub-decoding (funct3=000):
-#   funct7=8  (0b0001000): ADD_MULTI
-#   funct7=2  (0b0000010): U_ADD
-#   funct7=6  (0b0000110): S_ADD
-#   funct7=0  + func2=01 : ADD_RS3 (R4 format, func2 bits [26:25])
+#   funct7=0b0001000 (8):  ADD_MULTI
+#   funct7=0b0000010 (2):  U_ADD
+#   funct7=0b0000110 (6):  S_ADD
+#   funct7=0b0100000 (32): ADD_RS3 (uses func2=01)
 #
-# Note: funct7=32 has been replaced by func2=01 (ADD_RS3 R4 encoding).
-# func2 values: [0, 1, 2, 3] but only func2=1 is valid for ADD_RS3.
-#
-# Verification space (register space sampled to keep combinations manageable):
-#   8 × 128 × 4 × 4 × 4 × 4 = 262,144 raw combinations (safe for all hosts)
+# Verification space:
+#   8 × 128 × 32 × 32 × 32 = 33,554,432 raw combinations (~33M)
 #   oneof: funct3 ∈ {0, 1, 2}
-#   cross (funct3 → funct7):
-#     0: [2, 6, 8]    (ADD_RS3 uses func2, not funct7)
-#     1: [0]
-#     2: [96]
-#   cross (funct3 → func2):
-#     0: func2 ∈ {0, 1, 2, 3}  (ADD_RS3 = func2=1)
-#   Valid: 3×4×4×4×4 + 1×4×4×4 + 1×4×4×4 = 768 + 64 + 64 = 896 pass
-#   Full register range (32×32×32) available with rs1/rs2/rd ∈ [0, 31].
+#   cross: funct3=0 → funct7 ∈ {2, 6, 8, 32}
+#          funct3=1 → funct7 ∈ {0}
+#          funct3=2 → funct7 ∈ {96}
+#   Valid: 4×32×32×32 + 1×32×32×32 + 1×32×32×32 = 196,608 pass
 
 target: cva6_xif_ref
-encoding: r4
 fields:
   funct3:
     range: [0, 7]
   funct7:
     range: [0, 127]
-  func2:
-    range: [0, 3]
   rs1:
-    range: [0, 3]
+    range: [0, 31]
   rs2:
-    range: [0, 3]
+    range: [0, 31]
   rd:
-    range: [0, 3]
+    range: [0, 31]
 constraints:
   - type: oneof
     field: "funct3"
@@ -56,13 +46,8 @@ constraints:
     field_a: "funct3"
     field_b: "funct7"
     mapping:
-      0: [2, 6, 8]
+      0: [2, 6, 8, 32]
       1: [0]
       2: [96]
-  - type: cross
-    field_a: "funct3"
-    field_b: "func2"
-    mapping:
-      0: [0, 1, 2, 3]
 projector:
   type: sum

--- a/tests/fixtures/cva6_xif_ref_r4.xif.yaml
+++ b/tests/fixtures/cva6_xif_ref_r4.xif.yaml
@@ -1,0 +1,71 @@
+# CVA6 CV-X-IF encoding space — R4 format variant with func2 field.
+#
+# Based on cva6/verif/env/corev-dv/custom/cvxif_custom_instr.sv (verification
+# instruction definitions) and cva6/core/cvxif_instr_pkg.sv (coprocessor decode).
+#
+# This variant uses the R4 encoding layout to support the func2 field at bits
+# [26:25], replacing funct7=32 for ADD_RS3 encoding.
+#
+# Register fields are sampled (0..3) to keep combinations within safe limits
+# given the additional func2 dimension.
+#
+# Custom-3 opcode (0x7B):
+#   funct3=000: ADD variants  (funct7 sub-decoded, R4 for ADD_RS3)
+#   funct3=001: ADD / NOP     (funct7=0 only, NOP has rd=rs1=rs2=0)
+#   funct3=010: EXC           (funct7=96 only)
+#   funct3=011..111: illegal
+#
+# funct7 sub-decoding (funct3=000):
+#   funct7=8  (0b0001000): ADD_MULTI
+#   funct7=2  (0b0000010): U_ADD
+#   funct7=6  (0b0000110): S_ADD
+#   funct7=0  + func2=01 : ADD_RS3 (R4 format, func2 bits [26:25])
+#
+# Note: funct7=32 has been replaced by func2=01 (ADD_RS3 R4 encoding).
+# func2 values: [0, 1, 2, 3] but only func2=1 is valid for ADD_RS3.
+#
+# Verification space (register space sampled to keep combinations manageable):
+#   8 × 128 × 4 × 4 × 4 × 4 = 262,144 raw combinations (safe for all hosts)
+#   oneof: funct3 ∈ {0, 1, 2}
+#   cross (funct3 → funct7):
+#     0: [2, 6, 8]    (ADD_RS3 uses func2, not funct7)
+#     1: [0]
+#     2: [96]
+#   cross (funct3 → func2):
+#     0: func2 ∈ {0, 1, 2, 3}  (ADD_RS3 = func2=1)
+#   Valid: 3×4×4×4×4 + 1×4×4×4 + 1×4×4×4 = 768 + 64 + 64 = 896 pass
+#   Full register range (32×32×32) available with rs1/rs2/rd ∈ [0, 31].
+
+target: cva6_xif_ref_r4
+encoding: r4
+fields:
+  funct3:
+    range: [0, 7]
+  funct7:
+    range: [0, 127]
+  func2:
+    range: [0, 3]
+  rs1:
+    range: [0, 3]
+  rs2:
+    range: [0, 3]
+  rd:
+    range: [0, 3]
+constraints:
+  - type: oneof
+    field: "funct3"
+    values: [0, 1, 2]
+  - type: cross
+    field_a: "funct3"
+    field_b: "funct7"
+    mapping:
+      0: [2, 6, 8]
+      1: [0]
+      2: [96]
+  - type: cross
+    field_a: "funct3"
+    field_b: "func2"
+    mapping:
+      0: [0, 1, 2, 3]
+projector:
+  type: sum


### PR DESCRIPTION
## Summary

Add proper EncodingLayout to VerificationSpec for RISC-V instruction encoding format support. R-type and R4 formats are now first-class concepts with explicit field-to-bit-position mappings.

## Changes

- `spec.rs`: Added `EncodingLayout` struct with `field_map: BTreeMap<String, FieldBitMapping>` — format-agnostic field-to-bit mapping
- `spec.rs`: Added `encoding: Option<EncodingLayout>` to `VerificationSpec`
- `xif.rs`: YAML parser supports `encoding: r` (R-type, default) and `encoding: r4` (R4 with func2)
- `xif.rs`: Built-in default layouts for R-type and R4
- `cva6_xif_ref.xif.yaml`: Added `func2` field, `encoding: r4`, updated cross constraints

R4 format layout: `{rs3[4:0], func2[1:0], rs2[4:0], rs1[4:0], funct3[2:0], rd[4:0], opcode[6:0]}`

## Verification

- `cargo test --release`: 14/14 pass, no regressions
- `cva6_xif_ref`: 262,144 total, 1,280 pass, 260,864 fail

Closes #17