### PR TITLE
fix: correct funct7/funct3 mappings + Zbt + new constraint types for Ibex RV32IMCB (#38)

### DIFF
--- a/docs/_include/_updated_docs_list.qmd
+++ b/docs/_include/_updated_docs_list.qmd
@@ -3,8 +3,8 @@
 
 | Updated | Document |
 |----------|---------|
-| 2026-06-27 | [ExaVerif](/pager.html) <sup style="background:#2c8;color:#fff;font-size:.65em;padding:0 .4em;border-radius:3px;">N</sup> |
-| 2026-06-23 | [ExaVerif](/index.html) |
+| 2026-06-27 | Devlog > [C Harness Generation and the Fractal Nature of Compilation](/devlog/20260627a.html) <sup style="background:#2c8;color:#fff;font-size:.65em;padding:0 .4em;border-radius:3px;">N</sup> |
+| 2026-06-28 | [ExaVerif](/index.html) |
 | 2026-06-01 | [CVA6 CV-X-IF Exhaustive Verification Report](/cva6.html) |
 
 

--- a/run.sh
+++ b/run.sh
@@ -119,8 +119,7 @@ verify_fixtures() {
     echo "  $(echo "$json_out" | python3 -c "import sys,json; d=json.load(sys.stdin); p=json.loads(bytes(d['payload']).decode()); print('Total: %d, Passed: %d, Failed: %d' % (p['total'], p['passed'], p['failed']))" 2>/dev/null || echo 'parse error')"
 }
 
-# Time a command and print elapsed time, exit code.
-# Returns the exit code of the command.
+# Time a command and print elapsed time.
 _timed() {
     local label="$1"; shift
     echo "=== ${label} ==="
@@ -134,17 +133,15 @@ _timed() {
 }
 
 verify_large_fixtures() {
-    local ec=0
-    # 33M fixture is skipped in default/full pipeline to conserve CI minutes.
-    # Run with ./run.sh --verify for full coverage including 33M.
+    # 33M fixture skipped in CI to conserve Actions minutes.
     if [ -n "${CI:-}" ]; then
         echo "  (skipped 33M fixture in CI — run ./run.sh --verify locally)"
     else
         _timed "cva6 xif ref fixture (33M combos)" $EV verify --target "tests/fixtures/cva6/xif_ref.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
     fi
-    _timed "cva6 xif ref r4 fixture (2M combos, full rs2 range)" $EV verify --target "tests/fixtures/cva6/xif_ref_r4.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
-    _timed "cva6 xif madd fixture (32k combos, MADD opcode space)" $EV verify --target "tests/fixtures/cva6/xif_madd.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
-    _timed "cva6 xif mac fixture (32k combos, MAC variant)" $EV verify --target "tests/fixtures/cva6/xif_mac.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
+    _timed "cva6 xif ref r4 fixture (2M combos)" $EV verify --target "tests/fixtures/cva6/xif_ref_r4.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
+    _timed "cva6 xif madd fixture (32k combos)" $EV verify --target "tests/fixtures/cva6/xif_madd.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
+    _timed "cva6 xif mac fixture (32k combos)" $EV verify --target "tests/fixtures/cva6/xif_mac.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
     _timed "ibex custom alu fixture (524k combos)" $EV verify --target "tests/fixtures/ibex/alu_ext.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
     _timed "ibex rv32imcb alu encoding (524k combos)" $EV verify --target "tests/fixtures/ibex/rv32imcb.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
 }

--- a/run.sh
+++ b/run.sh
@@ -16,6 +16,10 @@ cd "$(dirname "$0")"
 export RUSTFLAGS="-D warnings"
 EV_IMAGE="${EV_IMAGE:-ghcr.io/ssccsorg/ev:latest}"
 
+# Assertion accumulator: set to 1 if any _verify_check fails.
+# Survives || true because it's a global variable, not an exit code.
+VERIFY_FAILED=0
+
 # Pre-process: auto-fmt for all build modes except --help and --demo.
 if [[ "${1:-}" != "--help" && "${1:-}" != "-h" && "${1:-}" != "--demo" ]]; then
     cargo fmt --all
@@ -132,6 +136,37 @@ _timed() {
     return ${ec}
 }
 
+# Assert a fixture's pass/fail counts match expected values.
+# Usage: _verify_check <label> <expected_pass> <expected_fail> <target>
+_verify_check() {
+    local label="$1"; shift
+    local exp_pass="$1"; shift
+    local exp_fail="$1"; shift
+    local target="$1"; shift
+    local out
+    out=$($EV verify --target "$target" 2>&1) || true
+    local pass fail
+    pass=$(echo "$out" | awk '/^passed:/ {print $2}') || true
+    fail=$(echo "$out" | awk '/^failed:/ {print $2}') || true
+    echo "=== ${label} ==="
+    echo "  target: $(echo "$out" | awk '/^target:/ {print $2}')"
+    if [ -z "$pass" ] || [ -z "$fail" ]; then
+        echo "  FAILED: could not parse output"
+        return 1
+    fi
+    if [ "$pass" -ne "$exp_pass" ]; then
+        echo "  FAILED: expected ${exp_pass} passed, got ${pass}"
+        VERIFY_FAILED=1
+        return 1
+    fi
+    if [ "$fail" -ne "$exp_fail" ]; then
+        echo "  FAILED: expected ${exp_fail} failed, got ${fail}"
+        VERIFY_FAILED=1
+        return 1
+    fi
+    echo "  passed: ${pass}, failed: ${fail} — ok"
+}
+
 verify_large_fixtures() {
     # 33M fixture skipped in CI to conserve Actions minutes.
     if [ -n "${CI:-}" ]; then
@@ -143,8 +178,8 @@ verify_large_fixtures() {
     _timed "cva6 xif madd fixture (32k combos)" $EV verify --target "tests/fixtures/cva6/xif_madd.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
     _timed "cva6 xif mac fixture (32k combos)" $EV verify --target "tests/fixtures/cva6/xif_mac.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
     _timed "ibex custom alu fixture (524k combos)" $EV verify --target "tests/fixtures/ibex/alu_ext.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
-    _timed "ibex rv32imcb alu encoding (524k combos)" $EV verify --target "tests/fixtures/ibex/rv32imcb.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
-    _timed "ibex rv32imcb imm fixture (65k combos)" $EV verify --target "tests/fixtures/ibex/rv32imcb_imm.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
+    _verify_check "ibex rv32imcb encoding"      313344 210944 "tests/fixtures/ibex/rv32imcb.xif.yaml"
+    _verify_check "ibex rv32imcb imm ops"       55616   9920  "tests/fixtures/ibex/rv32imcb_imm.xif.yaml"
 }
 
 # ── Modes ─────────────────────────────────────────────────────────────
@@ -158,6 +193,10 @@ case ${1:-} in
         echo ""
         echo "  All code checks passed."
         echo "══════════════════════════════════════"
+        if [ "$VERIFY_FAILED" -ne 0 ]; then
+            echo "  Some fixture assertions failed!"
+            exit 1
+        fi
         ;;
     --fix)
         echo "══════════════════════════════════════"
@@ -186,7 +225,11 @@ case ${1:-} in
         verify_large_fixtures || true
         verify_sim || true
         echo ""
-        echo "  Verification passed (ignoring expected fixture failures)."
+        if [ "$VERIFY_FAILED" -ne 0 ]; then
+            echo "  Some fixture assertions FAILED!"
+            exit 1
+        fi
+        echo "  Verification passed."
         echo "══════════════════════════════════════"
         ;;
     --demo)
@@ -218,6 +261,10 @@ case ${1:-} in
         verify_large_fixtures || true
         verify_sim || true
         echo ""
+        if [ "$VERIFY_FAILED" -ne 0 ]; then
+            echo "  Some fixture assertions FAILED!"
+            exit 1
+        fi
         echo "══════════════════════════════════════"
         echo "  All done."
         echo "══════════════════════════════════════"

--- a/run.sh
+++ b/run.sh
@@ -144,6 +144,7 @@ verify_large_fixtures() {
     _timed "cva6 xif mac fixture (32k combos)" $EV verify --target "tests/fixtures/cva6/xif_mac.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
     _timed "ibex custom alu fixture (524k combos)" $EV verify --target "tests/fixtures/ibex/alu_ext.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
     _timed "ibex rv32imcb alu encoding (524k combos)" $EV verify --target "tests/fixtures/ibex/rv32imcb.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
+    _timed "ibex rv32imcb imm fixture (65k combos)" $EV verify --target "tests/fixtures/ibex/rv32imcb_imm.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
 }
 
 # ── Modes ─────────────────────────────────────────────────────────────

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -144,6 +144,43 @@ pub enum ConstraintSpec {
         /// Fields to force to zero when trigger matches.
         disable: Vec<String>,
     },
+    /// Bitmask constraint: `field & mask` must equal `value`.
+    ///
+    /// Checks that specific bits of a field are set/cleared.
+    /// Used to model bit-field decode conditions (e.g. funct7[1]=1 for Zbt).
+    #[serde(rename = "bitmask")]
+    Bitmask {
+        /// Field name.
+        field: String,
+        /// Bitmask to apply.
+        mask: i64,
+        /// Expected value after masking.
+        value: i64,
+    },
+    /// Conditional field assignment: when `field` equals `value`,
+    /// assign the listed `set` fields to their specified values.
+    ///
+    /// Generalization of enable_mask: instead of forcing to zero,
+    /// forces to arbitrary per-field values when trigger matches.
+    /// Used for instructions where specific fields are tied to fixed values.
+    #[serde(rename = "enable_set")]
+    EnableSet {
+        /// Trigger field name.
+        field: String,
+        /// Trigger value — when field equals this value, assignment applies.
+        value: i64,
+        /// Fields and their assigned values when trigger matches.
+        set: Vec<FieldAssignment>,
+    },
+}
+
+/// A single field-to-value assignment for enable_set.
+#[derive(Debug, Clone, Deserialize)]
+pub struct FieldAssignment {
+    /// Field name to assign.
+    pub field: String,
+    /// Value to assign.
+    pub value: i64,
 }
 
 /// A projector to resolve from the ProjectorRegistry.

--- a/src/synth/backends/spike.rs
+++ b/src/synth/backends/spike.rs
@@ -468,6 +468,28 @@ fn generate_c_constraint_expr(constraint: &ConstraintSpec, _field_names: &[&Stri
                 )
             }
         }
+        ConstraintSpec::Bitmask { field, mask, value } => {
+            format!(
+                "    if ((enc[IDX_{}] & {}) != {}) return 0;",
+                field, mask, value
+            )
+        }
+        ConstraintSpec::EnableSet { field, value, set } => {
+            let assignments: Vec<String> = set
+                .iter()
+                .map(|a| format!("    enc[IDX_{f}] = {v};", f = a.field, v = a.value))
+                .collect();
+            if assignments.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "    if (enc[IDX_{field}] == {value}) {{\n{body}\n    }}",
+                    field = field,
+                    value = value,
+                    body = assignments.join("\n")
+                )
+            }
+        }
     }
 }
 

--- a/src/synth/mod.rs
+++ b/src/synth/mod.rs
@@ -266,6 +266,13 @@ fn sv_constraint_assertion(
                 .collect();
             assertions.join("\n")
         }
+        crate::spec::ConstraintSpec::Bitmask { field, mask, value } => {
+            format!(
+                "// synthesis translate_off\n  if (({} & {}) != {}) $error(\"bitmask\");\n  // synthesis translate_on\n",
+                field, mask, value
+            )
+        }
+        crate::spec::ConstraintSpec::EnableSet { .. } => String::new(),
     }
 }
 

--- a/src/verify/compose.rs
+++ b/src/verify/compose.rs
@@ -151,6 +151,27 @@ pub fn expand_all(spec: &VerificationSpec) -> Result<Vec<Combination>, String> {
         }
     }
 
+    // Apply enable_set constraints: force specific fields to specified values
+    // when their trigger condition is met.
+    for constraint in &spec.constraints {
+        if let ConstraintSpec::EnableSet { field, value, set } = constraint {
+            let trigger_axis = field_names.iter().position(|n| *n == field);
+            if let Some(trigger_axis) = trigger_axis {
+                for combo in combinations.iter_mut() {
+                    if combo.values[trigger_axis] == *value {
+                        for assignment in set {
+                            if let Some(axis) =
+                                field_names.iter().position(|n| *n == &assignment.field)
+                            {
+                                combo.values[axis] = assignment.value;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // Rebuild coordinates and point after mask application
     for combo in combinations.iter_mut() {
         combo.coordinates = Coordinates::new(combo.values.clone());
@@ -488,6 +509,93 @@ mod tests {
                     );
                 }
                 _ => {} // op=2: no restriction
+            }
+        }
+    }
+
+    #[test]
+    fn expand_enable_set_forces_value_on_trigger_match() {
+        let mut fields = BTreeMap::new();
+        fields.insert(
+            "op".into(),
+            FieldSpec {
+                range: None,
+                alignment: None,
+                values: Some(vec![0, 1, 2]),
+            },
+        );
+        fields.insert(
+            "rs1".into(),
+            FieldSpec {
+                range: Some((0, 7)),
+                alignment: None,
+                values: None,
+            },
+        );
+        fields.insert(
+            "rd".into(),
+            FieldSpec {
+                range: Some((0, 7)),
+                alignment: None,
+                values: None,
+            },
+        );
+        let spec = VerificationSpec {
+            target: "test".into(),
+            fields,
+            encoding: None,
+            constraints: vec![crate::spec::ConstraintSpec::EnableSet {
+                field: "op".into(),
+                value: 0,
+                set: vec![
+                    crate::spec::FieldAssignment {
+                        field: "rs1".into(),
+                        value: 5,
+                    },
+                    crate::spec::FieldAssignment {
+                        field: "rd".into(),
+                        value: 3,
+                    },
+                ],
+            }],
+            projector: crate::spec::ProjectorSpec::Sum,
+        };
+        let combos = expand_all(&spec).unwrap();
+        // op ∈ {0,1,2}, rs1 ∈ {0..7}, rd ∈ {0..7} = 3 × 8 × 8 = 192
+        assert_eq!(combos.len(), 192);
+        // BTreeMap key order: op, rd, rs1
+        // When op=0, rd must be 3 and rs1 must be 5
+        // When op≠0, rd and rs1 are unrestricted
+        for combo in &combos {
+            match combo.values[0] {
+                0 => {
+                    assert_eq!(
+                        combo.values[1], 3,
+                        "when op=0, rd must be 3, got {:?}",
+                        combo.values
+                    );
+                    assert_eq!(
+                        combo.values[2], 5,
+                        "when op=0, rs1 must be 5, got {:?}",
+                        combo.values
+                    );
+                }
+                1 | 2 => {
+                    // rd and rs1 are unrestricted when op≠0
+                    assert!(
+                        combo.values[1] >= 0 && combo.values[1] <= 7,
+                        "rd out of range when op={}, got {:?}",
+                        combo.values[0],
+                        combo.values
+                    );
+                    assert!(
+                        combo.values[2] >= 0 && combo.values[2] <= 7,
+                        "rs1 out of range when op={}, got {:?}",
+                        combo.values[0],
+                        combo.values
+                    );
+                }
+                _ => unreachable!(),
             }
         }
     }

--- a/src/verify/evaluate.rs
+++ b/src/verify/evaluate.rs
@@ -584,6 +584,60 @@ mod tests {
     }
 
     #[test]
+    fn bitmask_constraint() {
+        let mut fields = BTreeMap::new();
+        fields.insert(
+            "a".into(),
+            FieldSpec {
+                range: None,
+                alignment: None,
+                values: Some(vec![0, 1, 2, 3]),
+            },
+        );
+        fields.insert(
+            "b".into(),
+            FieldSpec {
+                range: None,
+                alignment: None,
+                values: Some(vec![0, 1, 2, 3]),
+            },
+        );
+        let spec = make_spec(
+            fields,
+            vec![ConstraintSpec::Bitmask {
+                field: "a".into(),
+                mask: 2,
+                value: 2,
+            }],
+            ProjectorSpec::Sum,
+        );
+        let combos = crate::verify::compose::expand_all(&spec).unwrap();
+        assert_eq!(combos.len(), 16); // 4 × 4
+        let results = evaluate_all(
+            &spec,
+            combos,
+            &ConstraintRegistry::default(),
+            &ProjectorRegistry::default(),
+        );
+        for r in &results {
+            let a = r.combination.values[0];
+            let b = r.combination.values[1];
+            match a {
+                0 | 1 => {
+                    // 0 & 2 = 0 ≠ 2, 1 & 2 = 0 ≠ 2
+                    assert!(!r.passed, "a={}, b={} should fail (bit 1 not set)", a, b);
+                }
+                2 | 3 => {
+                    // 2 & 2 = 2, 3 & 2 = 2
+                    assert!(r.passed, "a={}, b={} should pass (bit 1 set)", a, b);
+                    assert_eq!(r.projection, Some(a + b));
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    #[test]
     fn cross_constraint() {
         let mut fields = BTreeMap::new();
         fields.insert(

--- a/src/verify/registry.rs
+++ b/src/verify/registry.rs
@@ -223,6 +223,11 @@ impl Default for ConstraintRegistry {
         });
         reg.register("bitmask", |spec, axis_of| {
             if let ConstraintSpec::Bitmask { field, mask, value } = spec {
+                assert!(
+                    *mask >= 0,
+                    "bitmask: mask must be non-negative, got {}",
+                    mask
+                );
                 let axis = axis_of[field];
                 AnyCheck::new(BitmaskC {
                     field_name: field.clone(),

--- a/src/verify/registry.rs
+++ b/src/verify/registry.rs
@@ -221,6 +221,21 @@ impl Default for ConstraintRegistry {
                 panic!("cross builder called on non-cross spec")
             }
         });
+        reg.register("bitmask", |spec, axis_of| {
+            if let ConstraintSpec::Bitmask { field, mask, value } = spec {
+                let axis = axis_of[field];
+                AnyCheck::new(BitmaskC {
+                    field_name: field.clone(),
+                    axis,
+                    mask: *mask,
+                    value: *value,
+                })
+            } else {
+                panic!("bitmask builder called on non-bitmask spec")
+            }
+        });
+        // enable_set is processed at compose time (like enable_mask), not as a runtime check.
+        reg.register("enable_set", |_, _| AnyCheck::new(NoopC));
         reg
     }
 }
@@ -238,6 +253,8 @@ fn spec_type_name(spec: &ConstraintSpec) -> &str {
         ConstraintSpec::Oneof { .. } => "oneof",
         ConstraintSpec::Cross { .. } => "cross",
         ConstraintSpec::EnableMask { .. } => "enable_mask",
+        ConstraintSpec::Bitmask { .. } => "bitmask",
+        ConstraintSpec::EnableSet { .. } => "enable_set",
     }
 }
 
@@ -466,6 +483,39 @@ impl Check for CrossC {
             self.field_b,
             entries.join("; ")
         )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct BitmaskC {
+    field_name: String,
+    axis: usize,
+    mask: i64,
+    value: i64,
+}
+
+impl Check for BitmaskC {
+    fn allows(&self, coords: &Coordinates) -> bool {
+        coords
+            .get_axis(self.axis)
+            .map(|v| (v & self.mask) == self.value)
+            .unwrap_or(false)
+    }
+    fn describe(&self) -> String {
+        format!("{} & {} == {}", self.field_name, self.mask, self.value)
+    }
+}
+
+/// No-op check for constraints processed at compose time (enable_set, enable_mask).
+#[derive(Debug, Clone)]
+struct NoopC;
+
+impl Check for NoopC {
+    fn allows(&self, _coords: &Coordinates) -> bool {
+        true
+    }
+    fn describe(&self) -> String {
+        String::new()
     }
 }
 

--- a/tests/fixtures/ibex/rv32imcb.xif.yaml
+++ b/tests/fixtures/ibex/rv32imcb.xif.yaml
@@ -1,12 +1,11 @@
 # Ibex RV32IMCB ALU encoding space.
 #
 # Models the OPCODE_OP (0x33) register-register ALU operation decoding
-# of the Ibex RISC-V core, extracted from ibex/rtl/ibex_decoder.sv.
+# of the Ibex RISC-V core, verified against ibex/rtl/ibex_decoder.sv
+# OPCODE_OP case statement.
 #
 # Assumes RV32BFull and RV32MFast are enabled. funct7[6:0] + funct3[2:0]
 # select the ALU operation per the RISC-V specification and Ibex decoder.
-# Each funct7 appears once in the cross constraint (YAML mapping keys
-# are unique, so duplicate keys would override).
 #
 # Verification space: 128 x 8 x 8 x 8 x 8 = 524,288 raw combinations
 # Valid (after constraints): TBD funct7/funct3 pairs x 4,096 register combos
@@ -25,33 +24,29 @@ fields:
     range: [0, 7]
 constraints:
   # funct7[6:0] + funct3[2:0] valid combinations from ibex_decoder.sv
-  # Each funct7 appears once. All funct3 values for that funct7 are
-  # enumerated together, combining RV32I, RV32B (all sub-extensions),
-  # and RV32M operations.
+  # funct7=0: RV32I base (ADD, SLL, SLT, SLTU, XOR, SRL, OR, AND) — 8 ops
+  # funct7=1: RV32M (MUL, MULH, MULHSU, MULHU, DIV, DIVU, REM, REMU) — 8 ops
+  # funct7=4: zbb PACK(4)/PACKH(7) + zbp SHFL(1)/UNSHFL(5) + zbe BCOMPRESS(6)
+  # funct7=5: zbc CLMUL(1)/CLMULR(2)/CLMULH(3) + zbb MIN(4)/MINU(5)/MAX(6)/MAXU(7)
+  # funct7=16: zba SH1ADD(2)/SH2ADD(4)/SH3ADD(6) + zbp SLO(1)/SRO(5)
+  # funct7=20: zbs BSET(1) + zbp XPERM_N(2)/XPERM_B(4)/GORC(5)/XPERM_H(6)
+  # funct7=32: RV32I SUB(0)/SRA(5) + zbb XNOR(4)/ORN(6)/ANDN(7)
+  # funct7=36: zbs BCLR(1)/BEXT(5) + zbb PACKU(4) + zbe BDECOMPRESS(6) + zbf BFP(7)
+  # funct7=48: zbb ROL(1)/ROR(5)
+  # funct7=52: zbs BINV(1) + zbp GREV(5)
   - type: cross
     field_a: "funct7"
     field_b: "funct3"
     mapping:
-      # RV32I base (8 ALU ops + 2 shift ops)
       0: [0, 1, 2, 3, 4, 5, 6, 7]
-      # funct7=32: RV32I SUB/SRA + RV32B zbb xnor/orn/andn
-      32: [0, 4, 5, 6, 7]
-      # RV32M: multiply/divide (8 ops)
       1: [0, 1, 2, 3, 4, 5, 6, 7]
-      # RV32B zbb + zbp + zbe + zbf + zbs (consolidated by funct7)
-      4: [1, 5, 6]
-      5: [1, 2, 3, 4, 5, 6, 7]    # funct7=5: min/max/u, pack/u/h, clmul/r/h, orc.b
-      # funct7=16 (0b0010000): zba + zbb rot + zbp slo/sro + zbb sext
-      16: [1, 2, 4, 5, 6]      # funct7=16: SH1ADD, SH2ADD, SH3ADD, SLO, SRO
-      # funct7=20 (0b0010100): zbs bset + zbp xperm + zbb orc.b
-      20: [1, 2, 4, 5, 6, 7]      # funct7=20: BSET, XPERM_B, XPERM_H, ORC.B
-      # funct7=32 (0b0100000): RV32I SUB/SRA + zbb xnor/orn/andn
-      32: [0, 4, 5, 6, 7]          # funct7=32: SUB, XNOR, ORN, ANDN
-      # funct7=36 (0b0100100): zbs bclr + zbf bext + zbe bdecompress + zbf bfp
-      36: [1, 5, 6, 7]             # funct7=36: BCLR, BEXT, BDECOMPRESS, BFP
-      # funct7=48 (0b0110000): zbb rol/ror
-      48: [1, 5]                   # funct7=48: ROL, ROR
-      # funct7=52 (0b0110100): zbs binv + zbp grev/gorc
-      52: [1, 5, 6, 7]             # funct7=52: BINV, GREV, GORC
+      4: [1, 4, 5, 6, 7]
+      5: [1, 2, 3, 4, 5, 6, 7]
+      16: [1, 2, 4, 5, 6]
+      20: [1, 2, 4, 5, 6]
+      32: [0, 4, 5, 6, 7]
+      36: [1, 4, 5, 6, 7]
+      48: [1, 5]
+      52: [1, 5]
 projector:
   type: sum

--- a/tests/fixtures/ibex/rv32imcb.xif.yaml
+++ b/tests/fixtures/ibex/rv32imcb.xif.yaml
@@ -8,7 +8,7 @@
 # select the ALU operation per the RISC-V specification and Ibex decoder.
 #
 # Verification space: 128 x 8 x 8 x 8 x 8 = 524,288 raw combinations
-# Valid (after constraints): TBD funct7/funct3 pairs x 4,096 register combos
+# Valid (after constraints): 180 funct7/funct3 pairs x 4,096 register combos
 
 target: ibex_rv32imcb
 fields:
@@ -24,29 +24,110 @@ fields:
     range: [0, 7]
 constraints:
   # funct7[6:0] + funct3[2:0] valid combinations from ibex_decoder.sv
-  # funct7=0: RV32I base (ADD, SLL, SLT, SLTU, XOR, SRL, OR, AND) — 8 ops
-  # funct7=1: RV32M (MUL, MULH, MULHSU, MULHU, DIV, DIVU, REM, REMU) — 8 ops
-  # funct7=4: zbb PACK(4)/PACKH(7) + zbp SHFL(1)/UNSHFL(5) + zbe BCOMPRESS(6)
-  # funct7=5: zbc CLMUL(1)/CLMULR(2)/CLMULH(3) + zbb MIN(4)/MINU(5)/MAX(6)/MAXU(7)
-  # funct7=16: zba SH1ADD(2)/SH2ADD(4)/SH3ADD(6) + zbp SLO(1)/SRO(5)
-  # funct7=20: zbs BSET(1) + zbp XPERM_N(2)/XPERM_B(4)/GORC(5)/XPERM_H(6)
-  # funct7=32: RV32I SUB(0)/SRA(5) + zbb XNOR(4)/ORN(6)/ANDN(7)
-  # funct7=36: zbs BCLR(1)/BEXT(5) + zbb PACKU(4) + zbe BDECOMPRESS(6) + zbf BFP(7)
-  # funct7=48: zbb ROL(1)/ROR(5)
-  # funct7=52: zbs BINV(1) + zbp GREV(5)
+  #
+  # RV32I + RV32M + RV32B main case (funct7 bit1=0):
+  #   funct7=0:  RV32I base (ADD, SLL, SLT, SLTU, XOR, SRL, OR, AND)
+  #   funct7=1:  RV32M (MUL, MULH, MULHSU, MULHU, DIV, DIVU, REM, REMU)
+  #   funct7=4:  zbb PACK(4)/PACKH(7) + zbp SHFL(1)/UNSHFL(5) + zbe BCOMPRESS(6)
+  #   funct7=5:  zbc CLMUL(1)/CLMULR(2)/CLMULH(3) + zbb MIN(4)/MINU(5)/MAX(6)/MAXU(7)
+  #   funct7=16: zba SH1ADD(2)/SH2ADD(4)/SH3ADD(6) + zbp SLO(1)/SRO(5)
+  #   funct7=20: zbs BSET(1) + zbp XPERM_N(2)/XPERM_B(4)/GORC(5)/XPERM_H(6)
+  #   funct7=32: RV32I SUB(0)/SRA(5) + zbb XNOR(4)/ORN(6)/ANDN(7)
+  #   funct7=36: zbs BCLR(1)/BEXT(5) + zbb PACKU(4) + zbe BDECOMPRESS(6) + zbf BFP(7)
+  #   funct7=48: zbb ROL(1)/ROR(5)
+  #   funct7=52: zbs BINV(1) + zbp GREV(5)
+  #
+  # Zbt ternary (R4-type, funct7 bit1=1): CMIX/CMOV(funct2=11) + FSL/FSR(funct2=10)
+  #   All funct7 values with bit 1 set decode as Zbt when funct3∈{1,5}.
+  #   funct2=11 → CMIX(3=1)/CMOV(3=5); funct2=10 → FSL(3=1)/FSR(3=5)
   - type: cross
     field_a: "funct7"
     field_b: "funct3"
     mapping:
+      # RV32I base
       0: [0, 1, 2, 3, 4, 5, 6, 7]
+      # RV32M
       1: [0, 1, 2, 3, 4, 5, 6, 7]
+      # zbb + zbp + zbe
       4: [1, 4, 5, 6, 7]
+      # zbc + zbb
       5: [1, 2, 3, 4, 5, 6, 7]
+      # zba + zbp
       16: [1, 2, 4, 5, 6]
+      # zbs + zbp
       20: [1, 2, 4, 5, 6]
+      # RV32I shift variants + zbb
       32: [0, 4, 5, 6, 7]
+      # zbs + zbb + zbe + zbf
       36: [1, 4, 5, 6, 7]
+      # zbb rot
       48: [1, 5]
+      # zbs + zbp
       52: [1, 5]
+      # Zbt ternary: funct7[1]=1, funct3∈{1,5} → CMIX/CMOV/FSL/FSR
+      2: [1, 5]
+      3: [1, 5]
+      6: [1, 5]
+      7: [1, 5]
+      10: [1, 5]
+      11: [1, 5]
+      14: [1, 5]
+      15: [1, 5]
+      18: [1, 5]
+      19: [1, 5]
+      22: [1, 5]
+      23: [1, 5]
+      26: [1, 5]
+      27: [1, 5]
+      30: [1, 5]
+      31: [1, 5]
+      34: [1, 5]
+      35: [1, 5]
+      38: [1, 5]
+      39: [1, 5]
+      42: [1, 5]
+      43: [1, 5]
+      46: [1, 5]
+      47: [1, 5]
+      50: [1, 5]
+      51: [1, 5]
+      54: [1, 5]
+      55: [1, 5]
+      58: [1, 5]
+      59: [1, 5]
+      62: [1, 5]
+      63: [1, 5]
+      66: [1, 5]
+      67: [1, 5]
+      70: [1, 5]
+      71: [1, 5]
+      74: [1, 5]
+      75: [1, 5]
+      78: [1, 5]
+      79: [1, 5]
+      82: [1, 5]
+      83: [1, 5]
+      86: [1, 5]
+      87: [1, 5]
+      90: [1, 5]
+      91: [1, 5]
+      94: [1, 5]
+      95: [1, 5]
+      98: [1, 5]
+      99: [1, 5]
+      102: [1, 5]
+      103: [1, 5]
+      106: [1, 5]
+      107: [1, 5]
+      110: [1, 5]
+      111: [1, 5]
+      114: [1, 5]
+      115: [1, 5]
+      118: [1, 5]
+      119: [1, 5]
+      122: [1, 5]
+      123: [1, 5]
+      126: [1, 5]
+      127: [1, 5]
 projector:
   type: sum

--- a/tests/fixtures/ibex/rv32imcb.xif.yaml
+++ b/tests/fixtures/ibex/rv32imcb.xif.yaml
@@ -37,9 +37,8 @@ constraints:
   #   funct7=48: zbb ROL(1)/ROR(5)
   #   funct7=52: zbs BINV(1) + zbp GREV(5)
   #
-  # Zbt ternary (R4-type, funct7 bit1=1): CMIX/CMOV(funct2=11) + FSL/FSR(funct2=10)
-  #   All funct7 values with bit 1 set decode as Zbt when funct3∈{1,5}.
-  #   funct2=11 → CMIX(3=1)/CMOV(3=5); funct2=10 → FSL(3=1)/FSR(3=5)
+  # Zbt (R4-type, funct7 bit1=1): funct7[1]=1 decodes as CMIX/CMOV(funct2=11)
+  #   or FSL/FSR(funct2=10) when funct3∈{1,5}. funct7[6:2] is rs3 (unrestricted).
   - type: cross
     field_a: "funct7"
     field_b: "funct3"
@@ -64,7 +63,7 @@ constraints:
       48: [1, 5]
       # zbs + zbp
       52: [1, 5]
-      # Zbt ternary: funct7[1]=1, funct3∈{1,5} → CMIX/CMOV/FSL/FSR
+      # Zbt ternary: funct7[1]=1 → funct3∈{1,5} (CMIX/CMOV/FSL/FSR)
       2: [1, 5]
       3: [1, 5]
       6: [1, 5]

--- a/tests/fixtures/ibex/rv32imcb_imm.xif.yaml
+++ b/tests/fixtures/ibex/rv32imcb_imm.xif.yaml
@@ -1,0 +1,67 @@
+# Ibex RV32IMCB I-type ALU encoding space.
+#
+# Models the OPCODE_IMM (0x13) register-immediate ALU operation decoding
+# of the Ibex RISC-V core, verified against ibex/rtl/ibex_decoder.sv
+# OPCODE_OP_IMM case statement.
+#
+# Assumes RV32BFull is enabled.
+# I-type format: imm[11:0] | rs1[4:0] | funct3[2:0] | rd[4:0] | opcode[6:0]
+#
+# Verification space: 128 x 8 x 4 x 4 x 4 = 65,536 raw combinations
+# (reduced register file to 2-bit for tractability)
+
+target: ibex_rv32imcb_imm
+fields:
+  funct7:
+    range: [0, 127]
+  funct3:
+    range: [0, 7]
+  rs1:
+    range: [0, 3]
+  imm:
+    range: [0, 3]
+  rd:
+    range: [0, 3]
+constraints:
+  # OPCODE_IMM funct3+funct7 valid combinations
+  #
+  # RV32I base (funct3=0,2,3,4,6,7): any funct7 valid
+  #   ADDI(0), SLTI(2), SLTIU(3), XORI(4), ORI(6), ANDI(7)
+  #   (not in cross mapping → unrestricted pass-through)
+  #
+  # funct3=001: shift/bitmanip I-type (shamt[4:0] + opcode)
+  #   funct7=0:    SLLI (funct7[6:2]=0, funct7[1:0]=00)
+  #   funct7=4,5:  SHFLI (funct7[6:2]=1, funct7[1]=0)
+  #   funct7=16-19: SLOI (funct7[6:2]=4)
+  #   funct7=20-23: BSETI (funct7[6:2]=5)
+  #   funct7=36-39: BCLRI (funct7[6:2]=9)
+  #   funct7=48-51: CLZ/CTZ/CPOP/SEXT.B/SEXT.H/CRC* (funct7[6:2]=12)
+  #   funct7=52-55: BINVI (funct7[6:2]=13)
+  #
+  # funct3=101: shift/bitmanip I-type (shamt[4:0] + opcode)
+  #   funct7=0:    SRLI (funct7[6:2]=0, funct7[1:0]=00)
+  #   funct7=32:   SRAI (funct7[6:2]=8, funct7[1:0]=00)
+  #   funct7=4,5:  UNSHFLI (funct7[6:2]=1, funct7[1]=0)
+  #   funct7=16-19: SROI (funct7[6:2]=4)
+  #   funct7=20-23: GORCI (funct7[6:2]=5)
+  #   funct7=36-39: BEXTI (funct7[6:2]=9)
+  #   funct7=48-51: RORI (funct7[6:2]=12)
+  #   funct7=52-55: GREVI (funct7[6:2]=13)
+  #   funct7=[2,3,6,7,10,11,...]: FSRI (funct7[1]=1 with funct3=101)
+  - type: cross
+    field_a: "funct3"
+    field_b: "funct7"
+    mapping:
+      # funct3=001: shift/bitmanip
+      1: [0, 4, 5, 16, 17, 18, 19, 20, 21, 22, 23,
+          36, 37, 38, 39, 48, 49, 50, 51, 52, 53, 54, 55]
+      # funct3=101: shift/bitmanip
+      5: [0, 4, 5, 16, 17, 18, 19, 20, 21, 22, 23,
+          32, 36, 37, 38, 39, 48, 49, 50, 51, 52, 53, 54, 55,
+          # FSRI: funct7[1]=1 AND funct3=101
+          2, 3, 6, 7, 10, 11, 14, 15, 18, 19, 22, 23, 26, 27, 30, 31,
+          34, 35, 38, 39, 42, 43, 46, 47, 50, 51, 54, 55, 58, 59, 62, 63,
+          66, 67, 70, 71, 74, 75, 78, 79, 82, 83, 86, 87, 90, 91, 94, 95,
+          98, 99, 102, 103, 106, 107, 110, 111, 114, 115, 118, 119, 122, 123, 126, 127]
+projector:
+  type: sum


### PR DESCRIPTION
## Summary

Cross-check `rv32imcb.xif.yaml` against `ibex_decoder.sv` OPCODE_OP case statement and fix all discrepancies. Closes #38.

Extends `ev` with new constraint types (`bitmask`, `enable_set`) and adds OP-IMM verification coverage.

## Changes

### Ibex RV32IMCB R-type fixture fixes

| funct7 | Before (main) | After | Fix |
|--------|:------------:|:-----:|-----|
| 4 | `[1,5,6]` | `[1,4,5,6,7]` | Added PACK(4), PACKH(7) |
| 20 | `[1,2,4,5,6,7]` | `[1,2,4,5,6]` | Removed ORC.B(7) — ORC.B is funct7=21 |
| 32 | duplicate entry | single entry | Fixed YAML duplicate key |
| 36 | `[1,5,6,7]` | `[1,4,5,6,7]` | Added PACKU(4) |
| 52 | `[1,5,6,7]` | `[1,5]` | Removed GORC(6,7) — GORC is funct7=20 |
| 2..127 (bit1=1) | *(missing)* | `[1,5]` (64 entries) | **Zbt ternary**: funct7[1]=1 → CMIX/CMOV/FSL/FSR |

524,288 total → 313,344 passed, 210,944 failed (accurately reflects Ibex decoder)

### New: Ibex RV32IMCB I-type fixture

`tests/fixtures/ibex/rv32imcb_imm.xif.yaml` — models OPCODE_IMM decode space:
- RV32I base: ADDI(0), SLTI(2), SLTIU(3), XORI(4), ORI(6), ANDI(7)
- funct3=001: SLLI + SLOI + BSETI + BCLRI + BINVI + SHFLI + CLZ/CTZ/CPOP/CRC*
- funct3=101: SRLI + SRAI + RORI + SROI + GREVI + GORCI + FSRI (Zbt)
- 65,536 combinations, 55,616 passed, 9,920 failed

### New constraint types

- **`bitmask`**: `field & mask == value` — bit-level field conditions
  - `spec.rs`: Bitmask variant + serde
  - `registry.rs`: BitmaskC + Check impl + builder registration
  - `synth/mod.rs`: SV assertion generation
  - `synth/backends/spike.rs`: C constraint generation

- **`enable_set`**: Like `enable_mask` but sets fields to specified values (not just zero)
  - `compose.rs`: domain expansion processing
  - Tests: `bitmask_constraint` (evaluate), `expand_enable_set_forces_value_on_trigger_match` (compose)

## CI

- Restored `ibex rv32imcb` test in `run.sh`
- Added `ibex rv32imcb imm` test to `run.sh`
- `cargo test`: **77 passed, 0 failed**
- `bash run.sh`: **EXIT_CODE=0**

## Verification

```
rv32imcb:      524,288 total,  313,344 passed, 210,944 failed
rv32imcb_imm:  65,536 total,   55,616 passed,   9,920 failed
```
