### PR TITLE
feat: integrate synTagma CoordSpace — structural enumeration replaces Vec-based expansion (#40)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "tagma-core",
  "tempfile",
  "tracing",
 ]
@@ -1188,6 +1189,11 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tagma-core"
+version = "0.1.0"
+source = "git+https://github.com/ssccsorg/tagma#205e3a0f948d583b0200dec7fa1243c474a7605a"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +19,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -113,6 +128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +167,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -233,6 +281,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +379,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +414,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "criterion",
  "hex",
  "indicatif",
  "reqwest",
@@ -397,6 +519,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +540,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -669,10 +808,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -773,6 +932,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +948,34 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -917,6 +1110,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1275,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
@@ -1239,6 +1490,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,6 +1681,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1796,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,10 @@ indicatif = "0.17"
 colored = "2"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 hex = "0.4"
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "bench"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tracing = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 sha2 = "0.10"
 tempfile = "3"
+tagma-core = { git = "https://github.com/ssccsorg/tagma", package = "tagma-core" }
 indicatif = "0.17"
 colored = "2"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -367,29 +367,39 @@ fn bench_constraint_check(c: &mut Criterion) {
 // Criterion configuration
 // ===========================================================================
 
+// Fast microbenchmarks (ns-µs scale): high sample count for tight CIs.
+criterion_group!(
+    name = coordspace;
+    config = Criterion::default().sample_size(1000);
+    targets = bench_space_lookup_valid, bench_space_lookup_invalid,
+              bench_constraint_check
+);
+
+// Expand/enumerate: ms scale for ibex/cva6, µs for small.
 criterion_group!(
     name = expand;
-    config = Criterion::default().sample_size(30);
+    config = Criterion::default().sample_size(100);
     targets = bench_expand_small, bench_enumerate_small,
               bench_expand_medium, bench_enumerate_medium,
               bench_expand_ibex, bench_enumerate_ibex,
               bench_expand_cva6_r4, bench_enumerate_cva6_r4
 );
 
+// Light evaluation: small/medium scale, runs in µs-ms.
 criterion_group!(
-    name = evaluate;
-    config = Criterion::default().sample_size(30);
+    name = eval_light;
+    config = Criterion::default().sample_size(100);
     targets = bench_evaluate_small, bench_structural_enum_small, bench_validate_small,
-              bench_evaluate_medium, bench_structural_enum_medium, bench_validate_medium,
-              bench_evaluate_ibex, bench_structural_enum_ibex, bench_validate_ibex,
+              bench_evaluate_medium, bench_structural_enum_medium, bench_validate_medium
+);
+
+// Heavy evaluation: ibex/cva6 scale, runs in seconds per iter.
+// 10 samples is practical: ibex evaluate = 36s, cva6 evaluate = 14s.
+criterion_group!(
+    name = eval_heavy;
+    config = Criterion::default().sample_size(10);
+    targets = bench_evaluate_ibex, bench_structural_enum_ibex, bench_validate_ibex,
               bench_evaluate_cva6_r4, bench_structural_enum_cva6_r4, bench_validate_cva6_r4
 );
 
-criterion_group!(
-    name = coordspace;
-    config = Criterion::default().sample_size(100);
-    targets = bench_space_lookup_valid, bench_space_lookup_invalid,
-              bench_constraint_check
-);
-
-criterion_main!(expand, evaluate, coordspace);
+criterion_main!(coordspace, expand, eval_light, eval_heavy);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,355 @@
+//! ev benchmarks — exhaustive verification pipeline performance.
+//!
+//! Measures domain expansion, constraint evaluation, and CoordSpace-based
+//! verification against the standard Vec-based pipeline.
+//!
+//! Run: cargo bench
+//! Filter: cargo bench -- expand  (runs only expand_* benchmarks)
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::collections::BTreeMap;
+
+use ev::spec::{ConstraintSpec, FieldSpec, ProjectorSpec, VerificationSpec};
+use ev::verify::compose::{coords_to_coord_vec, expand_all, EnumerateIter, MAX_COMBINATIONS};
+use ev::verify::evaluate::{evaluate_all, validate_into_space};
+use ev::verify::registry::{Check, ConstraintRegistry, ProjectorRegistry};
+
+// ===========================================================================
+// Helpers
+// ===========================================================================
+
+/// Small spec: 3 fields × 3 values = 27 combos.
+fn small_spec() -> VerificationSpec {
+    let mut fields = BTreeMap::new();
+    fields.insert("a".into(), FieldSpec { range: Some((0, 2)), alignment: None, values: None });
+    fields.insert("b".into(), FieldSpec { range: Some((0, 2)), alignment: None, values: None });
+    fields.insert("c".into(), FieldSpec { range: Some((0, 2)), alignment: None, values: None });
+    VerificationSpec {
+        target: "bench_small".into(),
+        fields,
+        encoding: None,
+        constraints: vec![],
+        projector: ProjectorSpec::Sum,
+    }
+}
+
+/// Medium spec: 5 fields × 8 values = 32,768 combos (ibex-like).
+fn medium_spec() -> VerificationSpec {
+    let mut fields = BTreeMap::new();
+    fields.insert("funct7".into(), FieldSpec { range: Some((0, 7)), alignment: None, values: None });
+    fields.insert("funct3".into(), FieldSpec { range: Some((0, 7)), alignment: None, values: None });
+    fields.insert("rs1".into(),    FieldSpec { range: Some((0, 7)), alignment: None, values: None });
+    fields.insert("rs2".into(),    FieldSpec { range: Some((0, 7)), alignment: None, values: None });
+    fields.insert("rd".into(),     FieldSpec { range: Some((0, 7)), alignment: None, values: None });
+    let mapping: std::collections::HashMap<i64, Vec<i64>> = [
+        (0, vec![0,1,2,3,4,5,6,7]),
+        (4, vec![1,4,5,6,7]),
+        (5, vec![1,2,3,4,5,6,7]),
+    ].into();
+    VerificationSpec {
+        target: "bench_medium".into(),
+        fields,
+        encoding: None,
+        constraints: vec![ConstraintSpec::Cross {
+            field_a: "funct7".into(),
+            field_b: "funct3".into(),
+            mapping,
+        }],
+        projector: ProjectorSpec::Sum,
+    }
+}
+
+/// Ibex rv32imcb spec (524,288 combos, Zbt + main case).
+fn ibex_spec() -> VerificationSpec {
+    let path = std::path::Path::new("tests/fixtures/ibex/rv32imcb.xif.yaml");
+    VerificationSpec::from_yaml(path).expect("failed to load rv32imcb fixture")
+}
+
+/// CVA6 XIF ref r4 spec (2,097,152 combos).
+fn cva6_r4_spec() -> VerificationSpec {
+    let path = std::path::Path::new("tests/fixtures/cva6/xif_ref_r4.xif.yaml");
+    VerificationSpec::from_yaml(path).expect("failed to load cva6 xif ref r4 fixture")
+}
+
+// ===========================================================================
+// Domain expansion: expand_all (Vec) vs EnumerateIter
+// ===========================================================================
+
+fn bench_expand_small(c: &mut Criterion) {
+    let spec = small_spec();
+    c.bench_function("expand/small_27", |b| {
+        b.iter(|| {
+            let combos = expand_all(black_box(&spec)).unwrap();
+            black_box(combos);
+        })
+    });
+}
+
+fn bench_enumerate_small(c: &mut Criterion) {
+    let spec = small_spec();
+    c.bench_function("enumerate/small_27", |b| {
+        b.iter(|| {
+            let iter = EnumerateIter::new(black_box(&spec));
+            let count = iter.count();
+            black_box(count);
+        })
+    });
+}
+
+fn bench_expand_medium(c: &mut Criterion) {
+    let spec = medium_spec();
+    c.bench_function("expand/medium_32k", |b| {
+        b.iter(|| {
+            let combos = expand_all(black_box(&spec)).unwrap();
+            black_box(combos);
+        })
+    });
+}
+
+fn bench_enumerate_medium(c: &mut Criterion) {
+    let spec = medium_spec();
+    c.bench_function("enumerate/medium_32k", |b| {
+        b.iter(|| {
+            let iter = EnumerateIter::new(black_box(&spec));
+            let count = iter.count();
+            black_box(count);
+        })
+    });
+}
+
+fn bench_expand_ibex(c: &mut Criterion) {
+    let spec = ibex_spec();
+    c.bench_function("expand/ibex_524k", |b| {
+        b.iter(|| {
+            let combos = expand_all(black_box(&spec)).unwrap();
+            black_box(combos);
+        })
+    });
+}
+
+fn bench_enumerate_ibex(c: &mut Criterion) {
+    let spec = ibex_spec();
+    c.bench_function("enumerate/ibex_524k", |b| {
+        b.iter(|| {
+            let iter = EnumerateIter::new(black_box(&spec));
+            let count = iter.count();
+            black_box(count);
+        })
+    });
+}
+
+// ===========================================================================
+// Evaluation: evaluate_all (Vec) vs validate_into_space (CoordSpace)
+// ===========================================================================
+
+fn bench_evaluate_small(c: &mut Criterion) {
+    let spec = small_spec();
+    let combos = expand_all(&spec).unwrap();
+    c.bench_function("evaluate/small_27", |b| {
+        b.iter(|| {
+            let results = evaluate_all(
+                black_box(&spec),
+                black_box(combos.clone()),
+                &ConstraintRegistry::default(),
+                &ProjectorRegistry::default(),
+            );
+            black_box(results);
+        })
+    });
+}
+
+fn bench_validate_small(c: &mut Criterion) {
+    let spec = small_spec();
+    c.bench_function("validate/small_27", |b| {
+        b.iter(|| {
+            let space = validate_into_space(black_box(&spec), &ConstraintRegistry::default());
+            black_box(space);
+        })
+    });
+}
+
+fn bench_evaluate_medium(c: &mut Criterion) {
+    let spec = medium_spec();
+    let combos = expand_all(&spec).unwrap();
+    c.bench_function("evaluate/medium_32k", |b| {
+        b.iter(|| {
+            let results = evaluate_all(
+                black_box(&spec),
+                black_box(combos.clone()),
+                &ConstraintRegistry::default(),
+                &ProjectorRegistry::default(),
+            );
+            black_box(results);
+        })
+    });
+}
+
+fn bench_validate_medium(c: &mut Criterion) {
+    let spec = medium_spec();
+    c.bench_function("validate/medium_32k", |b| {
+        b.iter(|| {
+            let space = validate_into_space(black_box(&spec), &ConstraintRegistry::default());
+            black_box(space);
+        })
+    });
+}
+
+fn bench_evaluate_ibex(c: &mut Criterion) {
+    let spec = ibex_spec();
+    let combos = expand_all(&spec).unwrap();
+    c.bench_function("evaluate/ibex_524k", |b| {
+        b.iter(|| {
+            let results = evaluate_all(
+                black_box(&spec),
+                black_box(combos.clone()),
+                &ConstraintRegistry::default(),
+                &ProjectorRegistry::default(),
+            );
+            let count = results.iter().filter(|r| r.passed).count();
+            black_box(count);
+        })
+    });
+}
+
+fn bench_validate_ibex(c: &mut Criterion) {
+    let spec = ibex_spec();
+    c.bench_function("validate/ibex_524k", |b| {
+        b.iter(|| {
+            let space = validate_into_space(black_box(&spec), &ConstraintRegistry::default());
+            let count = space.iter().count();
+            black_box(count);
+        })
+    });
+}
+
+// ===========================================================================
+// CoordSpace: lookup vs Vec scan for individual combination validity
+// ===========================================================================
+
+fn bench_space_lookup_valid(c: &mut Criterion) {
+    let spec = ibex_spec();
+    let space = validate_into_space(&spec, &ConstraintRegistry::default());
+    // A known valid combination: funct7=4, funct3=4 (PACK), rs1=0, rs2=0, rd=0
+    let valid_path = coords_to_coord_vec(&[4, 4, 0, 0, 0]).unwrap();
+    c.bench_function("coordspace/lookup_valid", |b| {
+        b.iter(|| {
+            let result = space.at(black_box(&valid_path));
+            black_box(result);
+        })
+    });
+}
+
+fn bench_space_lookup_invalid(c: &mut Criterion) {
+    let spec = ibex_spec();
+    let space = validate_into_space(&spec, &ConstraintRegistry::default());
+    // A known invalid combination: funct7=4, funct3=0 (not in mapping)
+    let invalid_path = coords_to_coord_vec(&[4, 0, 0, 0, 0]).unwrap();
+    c.bench_function("coordspace/lookup_invalid", |b| {
+        b.iter(|| {
+            let result = space.at(black_box(&invalid_path));
+            black_box(result);
+        })
+    });
+}
+
+// ===========================================================================
+// Constraint check: single combination
+// ===========================================================================
+
+fn bench_expand_cva6_r4(c: &mut Criterion) {
+    let spec = cva6_r4_spec();
+    c.bench_function("expand/cva6_r4_2M", |b| {
+        b.iter(|| {
+            let combos = expand_all(black_box(&spec)).unwrap();
+            black_box(combos);
+        })
+    });
+}
+
+fn bench_enumerate_cva6_r4(c: &mut Criterion) {
+    let spec = cva6_r4_spec();
+    c.bench_function("enumerate/cva6_r4_2M", |b| {
+        b.iter(|| {
+            let iter = EnumerateIter::new(black_box(&spec));
+            let count = iter.count();
+            black_box(count);
+        })
+    });
+}
+
+fn bench_evaluate_cva6_r4(c: &mut Criterion) {
+    let spec = cva6_r4_spec();
+    let combos = expand_all(&spec).unwrap();
+    c.bench_function("evaluate/cva6_r4_2M", |b| {
+        b.iter(|| {
+            let results = evaluate_all(
+                black_box(&spec),
+                black_box(combos.clone()),
+                &ConstraintRegistry::default(),
+                &ProjectorRegistry::default(),
+            );
+            let count = results.iter().filter(|r| r.passed).count();
+            black_box(count);
+        })
+    });
+}
+
+fn bench_validate_cva6_r4(c: &mut Criterion) {
+    let spec = cva6_r4_spec();
+    c.bench_function("validate/cva6_r4_2M", |b| {
+        b.iter(|| {
+            let space = validate_into_space(black_box(&spec), &ConstraintRegistry::default());
+            let count = space.iter().count();
+            black_box(count);
+        })
+    });
+}
+
+fn bench_constraint_check(c: &mut Criterion) {
+    let spec = ibex_spec();
+    let checks = ConstraintRegistry::default().build_all(&spec.constraints, &spec.fields);
+    let combo = expand_all(&spec).unwrap().into_iter().find(|c| c.values[0] == 4 && c.values[1] == 4).unwrap();
+    c.bench_function("constraint/check_single", |b| {
+        b.iter(|| {
+            let mut passes = true;
+            for check in &checks {
+                if !check.allows(black_box(combo.point.coordinates())) {
+                    passes = false;
+                    break;
+                }
+            }
+            black_box(passes);
+        })
+    });
+}
+
+// ===========================================================================
+// Criterion configuration
+// ===========================================================================
+
+criterion_group!(
+    name = expand;
+    config = Criterion::default().sample_size(10);
+    targets = bench_expand_small, bench_enumerate_small,
+              bench_expand_medium, bench_enumerate_medium,
+              bench_expand_ibex, bench_enumerate_ibex,
+              bench_expand_cva6_r4, bench_enumerate_cva6_r4
+);
+
+criterion_group!(
+    name = evaluate;
+    config = Criterion::default().sample_size(10);
+    targets = bench_evaluate_small, bench_validate_small,
+              bench_evaluate_medium, bench_validate_medium,
+              bench_evaluate_ibex, bench_validate_ibex,
+              bench_evaluate_cva6_r4, bench_validate_cva6_r4
+);
+
+criterion_group!(
+    name = coordspace;
+    config = Criterion::default().sample_size(100);
+    targets = bench_space_lookup_valid, bench_space_lookup_invalid,
+              bench_constraint_check
+);
+
+criterion_main!(expand, evaluate, coordspace);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -10,7 +10,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::collections::BTreeMap;
 
 use ev::spec::{ConstraintSpec, FieldSpec, ProjectorSpec, VerificationSpec};
-use ev::verify::compose::{coords_to_coord_vec, expand_all, EnumerateIter, MAX_COMBINATIONS};
+use ev::verify::compose::{coords_to_coord_vec, expand_all, EnumerateIter, StructuralEnum, MAX_COMBINATIONS};
 use ev::verify::evaluate::{evaluate_all, validate_into_space};
 use ev::verify::registry::{Check, ConstraintRegistry, ProjectorRegistry};
 
@@ -158,6 +158,16 @@ fn bench_evaluate_small(c: &mut Criterion) {
     });
 }
 
+fn bench_structural_enum_small(c: &mut Criterion) {
+    let spec = small_spec();
+    c.bench_function("struct_enum/small_27", |b| {
+        b.iter(|| {
+            let count = StructuralEnum::new(black_box(&spec)).count();
+            black_box(count);
+        })
+    });
+}
+
 fn bench_validate_small(c: &mut Criterion) {
     let spec = small_spec();
     c.bench_function("validate/small_27", |b| {
@@ -184,6 +194,16 @@ fn bench_evaluate_medium(c: &mut Criterion) {
     });
 }
 
+fn bench_structural_enum_medium(c: &mut Criterion) {
+    let spec = medium_spec();
+    c.bench_function("struct_enum/medium_32k", |b| {
+        b.iter(|| {
+            let count = StructuralEnum::new(black_box(&spec)).count();
+            black_box(count);
+        })
+    });
+}
+
 fn bench_validate_medium(c: &mut Criterion) {
     let spec = medium_spec();
     c.bench_function("validate/medium_32k", |b| {
@@ -206,6 +226,16 @@ fn bench_evaluate_ibex(c: &mut Criterion) {
                 &ProjectorRegistry::default(),
             );
             let count = results.iter().filter(|r| r.passed).count();
+            black_box(count);
+        })
+    });
+}
+
+fn bench_structural_enum_ibex(c: &mut Criterion) {
+    let spec = ibex_spec();
+    c.bench_function("struct_enum/ibex_524k", |b| {
+        b.iter(|| {
+            let count = StructuralEnum::new(black_box(&spec)).count();
             black_box(count);
         })
     });
@@ -294,6 +324,16 @@ fn bench_evaluate_cva6_r4(c: &mut Criterion) {
     });
 }
 
+fn bench_structural_enum_cva6_r4(c: &mut Criterion) {
+    let spec = cva6_r4_spec();
+    c.bench_function("struct_enum/cva6_r4_2M", |b| {
+        b.iter(|| {
+            let count = StructuralEnum::new(black_box(&spec)).count();
+            black_box(count);
+        })
+    });
+}
+
 fn bench_validate_cva6_r4(c: &mut Criterion) {
     let spec = cva6_r4_spec();
     c.bench_function("validate/cva6_r4_2M", |b| {
@@ -339,10 +379,10 @@ criterion_group!(
 criterion_group!(
     name = evaluate;
     config = Criterion::default().sample_size(10);
-    targets = bench_evaluate_small, bench_validate_small,
-              bench_evaluate_medium, bench_validate_medium,
-              bench_evaluate_ibex, bench_validate_ibex,
-              bench_evaluate_cva6_r4, bench_validate_cva6_r4
+    targets = bench_evaluate_small, bench_structural_enum_small, bench_validate_small,
+              bench_evaluate_medium, bench_structural_enum_medium, bench_validate_medium,
+              bench_evaluate_ibex, bench_structural_enum_ibex, bench_validate_ibex,
+              bench_evaluate_cva6_r4, bench_structural_enum_cva6_r4, bench_validate_cva6_r4
 );
 
 criterion_group!(

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -369,7 +369,7 @@ fn bench_constraint_check(c: &mut Criterion) {
 
 criterion_group!(
     name = expand;
-    config = Criterion::default().sample_size(10);
+    config = Criterion::default().sample_size(30);
     targets = bench_expand_small, bench_enumerate_small,
               bench_expand_medium, bench_enumerate_medium,
               bench_expand_ibex, bench_enumerate_ibex,
@@ -378,7 +378,7 @@ criterion_group!(
 
 criterion_group!(
     name = evaluate;
-    config = Criterion::default().sample_size(10);
+    config = Criterion::default().sample_size(30);
     targets = bench_evaluate_small, bench_structural_enum_small, bench_validate_small,
               bench_evaluate_medium, bench_structural_enum_medium, bench_validate_medium,
               bench_evaluate_ibex, bench_structural_enum_ibex, bench_validate_ibex,

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -10,7 +10,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::collections::BTreeMap;
 
 use ev::spec::{ConstraintSpec, FieldSpec, ProjectorSpec, VerificationSpec};
-use ev::verify::compose::{coords_to_coord_vec, expand_all, EnumerateIter, StructuralEnum, MAX_COMBINATIONS};
+use ev::verify::compose::{coords_to_coord_vec, expand_all, EnumerateIter, StructuralEnum};
 use ev::verify::evaluate::{evaluate_all, validate_into_space};
 use ev::verify::registry::{Check, ConstraintRegistry, ProjectorRegistry};
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -21,9 +21,30 @@ use ev::verify::registry::{Check, ConstraintRegistry, ProjectorRegistry};
 /// Small spec: 3 fields × 3 values = 27 combos.
 fn small_spec() -> VerificationSpec {
     let mut fields = BTreeMap::new();
-    fields.insert("a".into(), FieldSpec { range: Some((0, 2)), alignment: None, values: None });
-    fields.insert("b".into(), FieldSpec { range: Some((0, 2)), alignment: None, values: None });
-    fields.insert("c".into(), FieldSpec { range: Some((0, 2)), alignment: None, values: None });
+    fields.insert(
+        "a".into(),
+        FieldSpec {
+            range: Some((0, 2)),
+            alignment: None,
+            values: None,
+        },
+    );
+    fields.insert(
+        "b".into(),
+        FieldSpec {
+            range: Some((0, 2)),
+            alignment: None,
+            values: None,
+        },
+    );
+    fields.insert(
+        "c".into(),
+        FieldSpec {
+            range: Some((0, 2)),
+            alignment: None,
+            values: None,
+        },
+    );
     VerificationSpec {
         target: "bench_small".into(),
         fields,
@@ -36,16 +57,52 @@ fn small_spec() -> VerificationSpec {
 /// Medium spec: 5 fields × 8 values = 32,768 combos (ibex-like).
 fn medium_spec() -> VerificationSpec {
     let mut fields = BTreeMap::new();
-    fields.insert("funct7".into(), FieldSpec { range: Some((0, 7)), alignment: None, values: None });
-    fields.insert("funct3".into(), FieldSpec { range: Some((0, 7)), alignment: None, values: None });
-    fields.insert("rs1".into(),    FieldSpec { range: Some((0, 7)), alignment: None, values: None });
-    fields.insert("rs2".into(),    FieldSpec { range: Some((0, 7)), alignment: None, values: None });
-    fields.insert("rd".into(),     FieldSpec { range: Some((0, 7)), alignment: None, values: None });
+    fields.insert(
+        "funct7".into(),
+        FieldSpec {
+            range: Some((0, 7)),
+            alignment: None,
+            values: None,
+        },
+    );
+    fields.insert(
+        "funct3".into(),
+        FieldSpec {
+            range: Some((0, 7)),
+            alignment: None,
+            values: None,
+        },
+    );
+    fields.insert(
+        "rs1".into(),
+        FieldSpec {
+            range: Some((0, 7)),
+            alignment: None,
+            values: None,
+        },
+    );
+    fields.insert(
+        "rs2".into(),
+        FieldSpec {
+            range: Some((0, 7)),
+            alignment: None,
+            values: None,
+        },
+    );
+    fields.insert(
+        "rd".into(),
+        FieldSpec {
+            range: Some((0, 7)),
+            alignment: None,
+            values: None,
+        },
+    );
     let mapping: std::collections::HashMap<i64, Vec<i64>> = [
-        (0, vec![0,1,2,3,4,5,6,7]),
-        (4, vec![1,4,5,6,7]),
-        (5, vec![1,2,3,4,5,6,7]),
-    ].into();
+        (0, vec![0, 1, 2, 3, 4, 5, 6, 7]),
+        (4, vec![1, 4, 5, 6, 7]),
+        (5, vec![1, 2, 3, 4, 5, 6, 7]),
+    ]
+    .into();
     VerificationSpec {
         target: "bench_medium".into(),
         fields,
@@ -348,7 +405,11 @@ fn bench_validate_cva6_r4(c: &mut Criterion) {
 fn bench_constraint_check(c: &mut Criterion) {
     let spec = ibex_spec();
     let checks = ConstraintRegistry::default().build_all(&spec.constraints, &spec.fields);
-    let combo = expand_all(&spec).unwrap().into_iter().find(|c| c.values[0] == 4 && c.values[1] == 4).unwrap();
+    let combo = expand_all(&spec)
+        .unwrap()
+        .into_iter()
+        .find(|c| c.values[0] == 4 && c.values[1] == 4)
+        .unwrap();
     c.bench_function("constraint/check_single", |b| {
         b.iter(|| {
             let mut passes = true;

--- a/run.sh
+++ b/run.sh
@@ -43,6 +43,8 @@ code_checks() {
     cargo build --release
     echo "=== test ==="
     cargo test --release
+    echo "=== bench (struct_enum) ==="
+    cargo bench --bench bench -- "struct_enum/ibex" 2>&1 | grep -E 'struct_enum|time:' | head -4
 }
 
 # Run a tool-dependent command inside the CI container.
@@ -180,6 +182,8 @@ verify_large_fixtures() {
     _timed "ibex custom alu fixture (524k combos)" $EV verify --target "tests/fixtures/ibex/alu_ext.xif.yaml" 2>&1 | grep -E '(target:|total:|passed:|failed:)' || true
     _verify_check "ibex rv32imcb encoding"      313344 210944 "tests/fixtures/ibex/rv32imcb.xif.yaml"
     _verify_check "ibex rv32imcb imm ops"       55616   9920  "tests/fixtures/ibex/rv32imcb_imm.xif.yaml"
+    echo "=== structural enumeration bench ==="
+    cargo bench --bench bench -- "struct_enum/ibex|struct_enum/cva6" 2>&1 | grep -E 'struct_enum|time:' | head -6
 }
 
 # ── Modes ─────────────────────────────────────────────────────────────

--- a/src/verify/compose.rs
+++ b/src/verify/compose.rs
@@ -50,7 +50,7 @@ pub struct Combination {
 ///
 /// Set to 10 million to cover typical RISC-V XIF designs (4-6 fields, small domains)
 /// while preventing OOM from accidentally large specifications.
-pub const MAX_COMBINATIONS: usize = 34_000_000;
+pub const MAX_COMBINATIONS: usize = 1_000_000_000; // 1B — CoordSpace removes Vec allocation
 
 /// Expand all field domains into the full cartesian product.
 ///

--- a/src/verify/compose.rs
+++ b/src/verify/compose.rs
@@ -296,19 +296,6 @@ pub fn structural_filters(
         }
     }
 
-    // Also apply field-level range restrictions from FieldSpec
-    for (i, name) in field_names.iter().enumerate() {
-        let def = spec.fields.get(*name).expect("field must exist");
-        let restricted: Vec<i64> = allowed[i]
-            .iter()
-            .filter(|v| def.allows(**v))
-            .copied()
-            .collect();
-        if !restricted.is_empty() {
-            allowed[i] = restricted;
-        }
-    }
-
     (allowed, cross_maps)
 }
 
@@ -458,8 +445,12 @@ impl StructuralEnum {
         result
     }
 
-    /// Total number of structurally valid combinations.
-    /// Returns None if the product overflows.
+    /// Upper bound on structurally valid combinations.
+    ///
+    /// This is the product of per-field allowed values, which may be larger
+    /// than the true count because cross constraints are not reflected in
+    /// per-field value counts. For the exact count, iterate and count.
+    /// Returns None if the product overflows usize.
     pub fn total_combinations(&self) -> Option<usize> {
         let mut total: usize = 1;
         for i in 0..self.allowed.len() {

--- a/src/verify/compose.rs
+++ b/src/verify/compose.rs
@@ -207,14 +207,18 @@ pub fn coords_to_path<const N: usize>(coords: &[i64]) -> Option<CoordPath<N>> {
     Some(CoordPath::new(arr))
 }
 
+/// Type alias for structural filter result: (per-field allowed, cross mappings).
+pub type StructuralFilters = (
+    Vec<Vec<i64>>,
+    Vec<(usize, usize, std::collections::HashMap<i64, Vec<i64>>)>,
+);
+
 /// Build a structural filter from constraints.
 ///
 /// Returns per-field allowed values where constraints structurally
 /// restrict the space. Constraints that cannot be expressed as
 /// structural filters (eq, neq) are returned for runtime evaluation.
-pub fn structural_filters(
-    spec: &VerificationSpec,
-) -> (Vec<Vec<i64>>, Vec<(usize, usize, std::collections::HashMap<i64, Vec<i64>>)>) {
+pub fn structural_filters(spec: &VerificationSpec) -> StructuralFilters {
     use std::collections::HashMap;
 
     let field_names: Vec<&String> = spec.fields.keys().collect();
@@ -325,8 +329,10 @@ impl StructuralEnum {
 
         // Re-index cross maps: for each child field, store a reference
         // to its parent field and mapping
-        let mut indexed: std::collections::HashMap<usize, (usize, std::collections::HashMap<i64, Vec<i64>>)> =
-            std::collections::HashMap::new();
+        let mut indexed: std::collections::HashMap<
+            usize,
+            (usize, std::collections::HashMap<i64, Vec<i64>>),
+        > = std::collections::HashMap::new();
         for (parent, child, mapping) in cross_maps {
             indexed.insert(child, (parent, mapping));
         }
@@ -342,7 +348,7 @@ impl StructuralEnum {
         }
     }
 
-    fn advance_indices(&mut self, current_values: &mut Vec<i64>) -> bool {
+    fn advance_indices(&mut self, current_values: &mut [i64]) -> bool {
         for i in (0..self.indices.len()).rev() {
             // For cross-constrained fields, we may need to try multiple
             // values until we find one that satisfies the constraint.
@@ -417,7 +423,11 @@ impl StructuralEnum {
         let mut result = values.to_vec();
         for constraint in &self.constraints {
             match constraint {
-                ConstraintSpec::EnableMask { field, value, disable } => {
+                ConstraintSpec::EnableMask {
+                    field,
+                    value,
+                    disable,
+                } => {
                     if let Some(trigger_axis) = self.field_names.iter().position(|n| n == field) {
                         if result[trigger_axis] == *value {
                             for f in disable {
@@ -432,7 +442,9 @@ impl StructuralEnum {
                     if let Some(trigger_axis) = self.field_names.iter().position(|n| n == field) {
                         if result[trigger_axis] == *value {
                             for assignment in set {
-                                if let Some(axis) = self.field_names.iter().position(|n| n == &assignment.field) {
+                                if let Some(axis) =
+                                    self.field_names.iter().position(|n| n == &assignment.field)
+                                {
                                     result[axis] = assignment.value;
                                 }
                             }
@@ -552,33 +564,22 @@ impl EnumerateIter {
                     value,
                     disable,
                 } => {
-                    if let Some(trigger_axis) =
-                        self.field_names.iter().position(|n| n == field)
-                    {
+                    if let Some(trigger_axis) = self.field_names.iter().position(|n| n == field) {
                         if result[trigger_axis] == *value {
                             for f in disable {
-                                if let Some(axis) =
-                                    self.field_names.iter().position(|n| n == f)
-                                {
+                                if let Some(axis) = self.field_names.iter().position(|n| n == f) {
                                     result[axis] = 0;
                                 }
                             }
                         }
                     }
                 }
-                ConstraintSpec::EnableSet {
-                    field,
-                    value,
-                    set,
-                } => {
-                    if let Some(trigger_axis) =
-                        self.field_names.iter().position(|n| n == field)
-                    {
+                ConstraintSpec::EnableSet { field, value, set } => {
+                    if let Some(trigger_axis) = self.field_names.iter().position(|n| n == field) {
                         if result[trigger_axis] == *value {
                             for assignment in set {
                                 if let Some(axis) =
-                                    self.field_names.iter()
-                                        .position(|n| n == &assignment.field)
+                                    self.field_names.iter().position(|n| n == &assignment.field)
                                 {
                                     result[axis] = assignment.value;
                                 }

--- a/src/verify/compose.rs
+++ b/src/verify/compose.rs
@@ -1051,4 +1051,144 @@ mod tests {
             err
         );
     }
+
+    // ── coords_to_coord_vec ─────────────────────────────────────
+
+    #[test]
+    fn coords_to_coord_vec_basic() {
+        let path = coords_to_coord_vec(&[0, 1, 2, 3, 4]).unwrap();
+        assert_eq!(path.len(), 5);
+        assert_eq!(path[0].index(), 0);
+        assert_eq!(path[4].index(), 4);
+    }
+
+    #[test]
+    fn coords_to_coord_vec_out_of_range() {
+        let result = coords_to_coord_vec(&[0, 20000]);
+        assert!(result.is_none(), "values > 11171 should return None");
+    }
+
+    #[test]
+    fn coords_to_coord_vec_empty() {
+        let path = coords_to_coord_vec(&[]).unwrap();
+        assert!(path.is_empty());
+    }
+
+    // ── structural_filters ───────────────────────────────────────
+
+    #[test]
+    fn structural_filters_oneof_restricts_domain() {
+        let mut fields = BTreeMap::new();
+        fields.insert("x".into(), FieldSpec {
+            range: Some((0, 9)), alignment: None, values: None,
+        });
+        let spec = VerificationSpec {
+            target: "test".into(),
+            fields,
+            encoding: None,
+            constraints: vec![ConstraintSpec::Oneof {
+                field: "x".into(),
+                values: vec![2, 4, 6, 8],
+            }],
+            projector: crate::spec::ProjectorSpec::Sum,
+        };
+        let (allowed, cross_maps) = structural_filters(&spec);
+        assert_eq!(allowed.len(), 1);
+        assert_eq!(allowed[0], vec![2, 4, 6, 8]);
+        assert!(cross_maps.is_empty());
+    }
+
+    #[test]
+    fn structural_filters_bitmask_restricts_domain() {
+        let mut fields = BTreeMap::new();
+        fields.insert("a".into(), FieldSpec {
+            range: Some((0, 7)), alignment: None, values: None,
+        });
+        let spec = VerificationSpec {
+            target: "test".into(),
+            fields,
+            encoding: None,
+            constraints: vec![ConstraintSpec::Bitmask {
+                field: "a".into(),
+                mask: 2,
+                value: 2,
+            }],
+            projector: crate::spec::ProjectorSpec::Sum,
+        };
+        let (allowed, _) = structural_filters(&spec);
+        assert_eq!(allowed[0], vec![2, 3, 6, 7]);
+    }
+
+    #[test]
+    fn structural_filters_cross_produces_mapping() {
+        let mut fields = BTreeMap::new();
+        fields.insert("op".into(), FieldSpec {
+            range: None, alignment: None,
+            values: Some(vec![0, 1, 2]),
+        });
+        fields.insert("sub".into(), FieldSpec {
+            range: None, alignment: None,
+            values: Some(vec![0, 1, 2, 3]),
+        });
+        let mapping: std::collections::HashMap<i64, Vec<i64>> =
+            [(0, vec![0]), (1, vec![0, 1, 2])].into();
+        let spec = VerificationSpec {
+            target: "test".into(),
+            fields,
+            encoding: None,
+            constraints: vec![ConstraintSpec::Cross {
+                field_a: "op".into(),
+                field_b: "sub".into(),
+                mapping,
+            }],
+            projector: crate::spec::ProjectorSpec::Sum,
+        };
+        let (allowed, cross_maps) = structural_filters(&spec);
+        assert_eq!(allowed[0], vec![0, 1, 2]);
+        assert_eq!(allowed[1], vec![0, 1, 2, 3]);
+        assert_eq!(cross_maps.len(), 1);
+        assert_eq!(cross_maps[0].0, 0);
+        assert_eq!(cross_maps[0].1, 1);
+    }
+
+    // ── StructuralEnum (no cross) ────────────────────────────────
+
+    #[test]
+    fn structural_enum_no_cross_matches_expand_all() {
+        let mut fields = BTreeMap::new();
+        fields.insert("a".into(), FieldSpec {
+            range: Some((0, 2)), alignment: None, values: None,
+        });
+        fields.insert("b".into(), FieldSpec {
+            range: Some((0, 3)), alignment: None, values: None,
+        });
+        let spec = make_spec(fields);
+        let expand_count = expand_all(&spec).unwrap().len();
+        let struct_count = StructuralEnum::new(&spec).count();
+        assert_eq!(struct_count, expand_count,
+            "without constraints, StructuralEnum should match expand_all");
+    }
+
+    #[test]
+    fn structural_enum_with_oneof_reduces_space() {
+        let mut fields = BTreeMap::new();
+        fields.insert("x".into(), FieldSpec {
+            range: Some((0, 4)), alignment: None, values: None,
+        });
+        let spec = VerificationSpec {
+            target: "test".into(),
+            fields,
+            encoding: None,
+            constraints: vec![ConstraintSpec::Oneof {
+                field: "x".into(),
+                values: vec![0, 2, 4],
+            }],
+            projector: crate::spec::ProjectorSpec::Sum,
+        };
+        let expand_count = expand_all(&spec).unwrap().len();
+        assert_eq!(expand_count, 5);
+        let struct_count = StructuralEnum::new(&spec).count();
+        assert_eq!(struct_count, 3,
+            "oneof should reduce enumeration space");
+    }
 }

--- a/src/verify/compose.rs
+++ b/src/verify/compose.rs
@@ -1079,9 +1079,14 @@ mod tests {
     #[test]
     fn structural_filters_oneof_restricts_domain() {
         let mut fields = BTreeMap::new();
-        fields.insert("x".into(), FieldSpec {
-            range: Some((0, 9)), alignment: None, values: None,
-        });
+        fields.insert(
+            "x".into(),
+            FieldSpec {
+                range: Some((0, 9)),
+                alignment: None,
+                values: None,
+            },
+        );
         let spec = VerificationSpec {
             target: "test".into(),
             fields,
@@ -1101,9 +1106,14 @@ mod tests {
     #[test]
     fn structural_filters_bitmask_restricts_domain() {
         let mut fields = BTreeMap::new();
-        fields.insert("a".into(), FieldSpec {
-            range: Some((0, 7)), alignment: None, values: None,
-        });
+        fields.insert(
+            "a".into(),
+            FieldSpec {
+                range: Some((0, 7)),
+                alignment: None,
+                values: None,
+            },
+        );
         let spec = VerificationSpec {
             target: "test".into(),
             fields,
@@ -1122,14 +1132,22 @@ mod tests {
     #[test]
     fn structural_filters_cross_produces_mapping() {
         let mut fields = BTreeMap::new();
-        fields.insert("op".into(), FieldSpec {
-            range: None, alignment: None,
-            values: Some(vec![0, 1, 2]),
-        });
-        fields.insert("sub".into(), FieldSpec {
-            range: None, alignment: None,
-            values: Some(vec![0, 1, 2, 3]),
-        });
+        fields.insert(
+            "op".into(),
+            FieldSpec {
+                range: None,
+                alignment: None,
+                values: Some(vec![0, 1, 2]),
+            },
+        );
+        fields.insert(
+            "sub".into(),
+            FieldSpec {
+                range: None,
+                alignment: None,
+                values: Some(vec![0, 1, 2, 3]),
+            },
+        );
         let mapping: std::collections::HashMap<i64, Vec<i64>> =
             [(0, vec![0]), (1, vec![0, 1, 2])].into();
         let spec = VerificationSpec {
@@ -1156,25 +1174,42 @@ mod tests {
     #[test]
     fn structural_enum_no_cross_matches_expand_all() {
         let mut fields = BTreeMap::new();
-        fields.insert("a".into(), FieldSpec {
-            range: Some((0, 2)), alignment: None, values: None,
-        });
-        fields.insert("b".into(), FieldSpec {
-            range: Some((0, 3)), alignment: None, values: None,
-        });
+        fields.insert(
+            "a".into(),
+            FieldSpec {
+                range: Some((0, 2)),
+                alignment: None,
+                values: None,
+            },
+        );
+        fields.insert(
+            "b".into(),
+            FieldSpec {
+                range: Some((0, 3)),
+                alignment: None,
+                values: None,
+            },
+        );
         let spec = make_spec(fields);
         let expand_count = expand_all(&spec).unwrap().len();
         let struct_count = StructuralEnum::new(&spec).count();
-        assert_eq!(struct_count, expand_count,
-            "without constraints, StructuralEnum should match expand_all");
+        assert_eq!(
+            struct_count, expand_count,
+            "without constraints, StructuralEnum should match expand_all"
+        );
     }
 
     #[test]
     fn structural_enum_with_oneof_reduces_space() {
         let mut fields = BTreeMap::new();
-        fields.insert("x".into(), FieldSpec {
-            range: Some((0, 4)), alignment: None, values: None,
-        });
+        fields.insert(
+            "x".into(),
+            FieldSpec {
+                range: Some((0, 4)),
+                alignment: None,
+                values: None,
+            },
+        );
         let spec = VerificationSpec {
             target: "test".into(),
             fields,
@@ -1188,7 +1223,6 @@ mod tests {
         let expand_count = expand_all(&spec).unwrap().len();
         assert_eq!(expand_count, 5);
         let struct_count = StructuralEnum::new(&spec).count();
-        assert_eq!(struct_count, 3,
-            "oneof should reduce enumeration space");
+        assert_eq!(struct_count, 3, "oneof should reduce enumeration space");
     }
 }

--- a/src/verify/compose.rs
+++ b/src/verify/compose.rs
@@ -4,6 +4,7 @@
 //! cartesian product of all field domains.
 
 use crate::spec::{ConstraintSpec, VerificationSpec};
+use tagma_core::{Coord, CoordPath};
 
 /// A coordinate vector — one value per instruction field.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -179,6 +180,162 @@ pub fn expand_all(spec: &VerificationSpec) -> Result<Vec<Combination>, String> {
     }
 
     Ok(combinations)
+}
+
+/// Convert a coordinate vector to a CoordPath for CoordSpace indexing.
+///
+/// Returns None if any field value exceeds the u16 Coord range.
+pub fn coords_to_path<const N: usize>(coords: &[i64]) -> Option<CoordPath<N>> {
+    assert_eq!(coords.len(), N, "coords length must match CoordPath depth");
+    let mut arr: [Coord; N] = [Coord::new(0).unwrap(); N];
+    for (i, &v) in coords.iter().enumerate() {
+        let c = Coord::new(v as u16)?;
+        arr[i] = c;
+    }
+    Some(CoordPath::new(arr))
+}
+
+/// Lazy cartesian product iterator over field domains.
+///
+/// Unlike `expand_all()`, this iterator does not pre-allocate a Vec.
+/// Each combination is produced on demand, yielding O(1) memory
+/// regardless of total combination count.
+pub struct EnumerateIter {
+    domains: Vec<Vec<i64>>,
+    indices: Vec<usize>,
+    done: bool,
+    field_names: Vec<String>,
+    constraints: Vec<ConstraintSpec>,
+}
+
+impl EnumerateIter {
+    pub fn new(spec: &VerificationSpec) -> Self {
+        let field_names: Vec<String> = spec.fields.keys().cloned().collect();
+        let domains: Vec<Vec<i64>> = field_names
+            .iter()
+            .map(|name| {
+                let def = spec.fields.get(name).expect("field must exist");
+                def.expand()
+            })
+            .collect();
+        let indices = vec![0usize; domains.len()];
+        let done = domains.is_empty();
+        Self {
+            domains,
+            indices,
+            done,
+            field_names,
+            constraints: spec.constraints.clone(),
+        }
+    }
+}
+
+impl Iterator for EnumerateIter {
+    type Item = Combination;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        // Build the current combination from current indices
+        let values: Vec<i64> = self
+            .indices
+            .iter()
+            .enumerate()
+            .map(|(i, &idx)| self.domains[i][idx])
+            .collect();
+
+        // Advance to the next index vector
+        let mut carry = true;
+        for i in (0..self.indices.len()).rev() {
+            if carry {
+                self.indices[i] += 1;
+                if self.indices[i] >= self.domains[i].len() {
+                    self.indices[i] = 0;
+                } else {
+                    carry = false;
+                }
+            }
+        }
+        if carry {
+            self.done = true;
+        }
+
+        // Apply enable_mask and enable_set constraints
+        // (simplified: only handles basic case; full constraint processing
+        //  is delegated to evaluate_all / validate_into_space)
+        let final_values = self.apply_enable_masks(&values);
+
+        let coordinates = Coordinates::new(final_values.clone());
+        let point = Point::new(coordinates.clone());
+        Some(Combination {
+            values: final_values,
+            coordinates,
+            point,
+        })
+    }
+}
+
+impl EnumerateIter {
+    fn apply_enable_masks(&self, values: &[i64]) -> Vec<i64> {
+        let mut result = values.to_vec();
+        for constraint in &self.constraints {
+            match constraint {
+                ConstraintSpec::EnableMask {
+                    field,
+                    value,
+                    disable,
+                } => {
+                    if let Some(trigger_axis) =
+                        self.field_names.iter().position(|n| n == field)
+                    {
+                        if result[trigger_axis] == *value {
+                            for f in disable {
+                                if let Some(axis) =
+                                    self.field_names.iter().position(|n| n == f)
+                                {
+                                    result[axis] = 0;
+                                }
+                            }
+                        }
+                    }
+                }
+                ConstraintSpec::EnableSet {
+                    field,
+                    value,
+                    set,
+                } => {
+                    if let Some(trigger_axis) =
+                        self.field_names.iter().position(|n| n == field)
+                    {
+                        if result[trigger_axis] == *value {
+                            for assignment in set {
+                                if let Some(axis) =
+                                    self.field_names.iter()
+                                        .position(|n| n == &assignment.field)
+                                {
+                                    result[axis] = assignment.value;
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        result
+    }
+
+    /// Total number of combinations (domain product).
+    /// Returns None if the product overflows usize.
+    pub fn total_combinations(&self) -> Option<usize> {
+        let mut total: usize = 1;
+        for d in &self.domains {
+            total = total.checked_mul(d.len())?;
+        }
+        Some(total)
+    }
 }
 
 #[cfg(test)]

--- a/src/verify/compose.rs
+++ b/src/verify/compose.rs
@@ -182,6 +182,18 @@ pub fn expand_all(spec: &VerificationSpec) -> Result<Vec<Combination>, String> {
     Ok(combinations)
 }
 
+/// Convert a coordinate slice to a Vec<Coord> for DynCoordSpace indexing.
+///
+/// Returns None if any field value exceeds the u16 Coord range.
+pub fn coords_to_coord_vec(coords: &[i64]) -> Option<Vec<Coord>> {
+    let mut result = Vec::with_capacity(coords.len());
+    for &v in coords {
+        let c = Coord::new(v as u16)?;
+        result.push(c);
+    }
+    Some(result)
+}
+
 /// Convert a coordinate vector to a CoordPath for CoordSpace indexing.
 ///
 /// Returns None if any field value exceeds the u16 Coord range.

--- a/src/verify/compose.rs
+++ b/src/verify/compose.rs
@@ -207,6 +207,268 @@ pub fn coords_to_path<const N: usize>(coords: &[i64]) -> Option<CoordPath<N>> {
     Some(CoordPath::new(arr))
 }
 
+/// Build a structural filter from constraints.
+///
+/// Returns per-field allowed values where constraints structurally
+/// restrict the space. Constraints that cannot be expressed as
+/// structural filters (eq, neq) are returned for runtime evaluation.
+pub fn structural_filters(
+    spec: &VerificationSpec,
+) -> (Vec<Vec<i64>>, Vec<(usize, usize, std::collections::HashMap<i64, Vec<i64>>)>) {
+    use std::collections::HashMap;
+
+    let field_names: Vec<&String> = spec.fields.keys().collect();
+    let domains: Vec<Vec<i64>> = field_names
+        .iter()
+        .map(|name| {
+            let def = spec.fields.get(*name).expect("field must exist");
+            def.expand()
+        })
+        .collect();
+
+    // Start with full domain per field
+    let mut allowed: Vec<Vec<i64>> = domains.clone();
+    // Cross constraints: (parent_idx, child_idx, mapping)
+    let mut cross_maps: Vec<(usize, usize, HashMap<i64, Vec<i64>>)> = Vec::new();
+
+    for constraint in &spec.constraints {
+        match constraint {
+            // oneof: restrict field to specific values
+            ConstraintSpec::Oneof { field, values } => {
+                if let Some(idx) = field_names.iter().position(|n| *n == field) {
+                    // Intersect current allowed with the oneof values
+                    let current = &allowed[idx];
+                    let restricted: Vec<i64> = current
+                        .iter()
+                        .filter(|v| values.contains(v))
+                        .copied()
+                        .collect();
+                    if !restricted.is_empty() {
+                        allowed[idx] = restricted;
+                    }
+                }
+            }
+            // range: restrict field to [min, max]
+            ConstraintSpec::Range { field, min, max } => {
+                if let Some(idx) = field_names.iter().position(|n| *n == field) {
+                    let current = &allowed[idx];
+                    let restricted: Vec<i64> = current
+                        .iter()
+                        .filter(|v| **v >= *min && **v <= *max)
+                        .copied()
+                        .collect();
+                    if !restricted.is_empty() {
+                        allowed[idx] = restricted;
+                    }
+                }
+            }
+            // cross: field_a → field_b mapping
+            // Do NOT restrict field_b's domain here — the restriction is
+            // applied per-parent-value during enumeration via cross_maps.
+            // When field_a is NOT in the mapping, field_b is unrestricted.
+            ConstraintSpec::Cross {
+                field_a,
+                field_b,
+                mapping,
+            } => {
+                let idx_a = field_names.iter().position(|n| *n == field_a);
+                let idx_b = field_names.iter().position(|n| *n == field_b);
+                if let (Some(ia), Some(ib)) = (idx_a, idx_b) {
+                    cross_maps.push((ia, ib, mapping.clone()));
+                }
+            }
+            // bitmask: field & mask == value → filter field values
+            ConstraintSpec::Bitmask { field, mask, value } => {
+                if let Some(idx) = field_names.iter().position(|n| *n == field) {
+                    let current = &allowed[idx];
+                    let restricted: Vec<i64> = current
+                        .iter()
+                        .filter(|v| (**v & *mask) == *value)
+                        .copied()
+                        .collect();
+                    if !restricted.is_empty() {
+                        allowed[idx] = restricted;
+                    }
+                }
+            }
+            // eq, neq, lt, gt, le, ge, even: runtime only
+            _ => {}
+        }
+    }
+
+    // Also apply field-level range restrictions from FieldSpec
+    for (i, name) in field_names.iter().enumerate() {
+        let def = spec.fields.get(*name).expect("field must exist");
+        let restricted: Vec<i64> = allowed[i]
+            .iter()
+            .filter(|v| def.allows(**v))
+            .copied()
+            .collect();
+        if !restricted.is_empty() {
+            allowed[i] = restricted;
+        }
+    }
+
+    (allowed, cross_maps)
+}
+
+/// A structural iterator that generates only valid combinations
+/// by encoding constraints into the enumeration space.
+pub struct StructuralEnum {
+    /// Per-field allowed values after applying structural constraints.
+    allowed: Vec<Vec<i64>>,
+    /// Current index into each field's allowed values.
+    indices: Vec<usize>,
+    /// Cross mapping: field_a_idx → (field_b_idx, mapping)
+    /// When iterating field_b, use the current field_a value to
+    /// restrict which field_b values are valid.
+    cross_maps: std::collections::HashMap<usize, (usize, std::collections::HashMap<i64, Vec<i64>>)>,
+    /// Done flag.
+    done: bool,
+    /// Field names (for enable_mask/ enable_set).
+    field_names: Vec<String>,
+    /// Constraints for enable processing at enumeration time.
+    constraints: Vec<ConstraintSpec>,
+}
+
+impl StructuralEnum {
+    pub fn new(spec: &VerificationSpec) -> Self {
+        let (allowed, cross_maps) = structural_filters(spec);
+        let field_names: Vec<String> = spec.fields.keys().cloned().collect();
+
+        // Re-index cross maps: for each child field, store a reference
+        // to its parent field and mapping
+        let mut indexed: std::collections::HashMap<usize, (usize, std::collections::HashMap<i64, Vec<i64>>)> =
+            std::collections::HashMap::new();
+        for (parent, child, mapping) in cross_maps {
+            indexed.insert(child, (parent, mapping));
+        }
+
+        let n = allowed.len();
+        Self {
+            allowed,
+            indices: vec![0; n],
+            cross_maps: indexed,
+            done: n == 0,
+            field_names,
+            constraints: spec.constraints.clone(),
+        }
+    }
+
+    fn advance_indices(&mut self, current_values: &mut Vec<i64>) -> bool {
+        for i in (0..self.indices.len()).rev() {
+            // For cross-constrained fields, we may need to try multiple
+            // values until we find one that satisfies the constraint.
+            loop {
+                self.indices[i] += 1;
+                if self.indices[i] >= self.allowed[i].len() {
+                    self.indices[i] = 0;
+                    current_values[i] = self.allowed[i][0];
+                    break; // carry to next higher field
+                }
+                current_values[i] = self.allowed[i][self.indices[i]];
+
+                // Check cross constraint, if any
+                let cross_ok = if let Some((parent_idx, mapping)) = self.cross_maps.get(&i) {
+                    let parent_val = current_values[*parent_idx];
+                    mapping
+                        .get(&parent_val)
+                        .map(|vals| vals.contains(&current_values[i]))
+                        .unwrap_or(true) // not in mapping = unrestricted
+                } else {
+                    true
+                };
+
+                if cross_ok {
+                    return false; // found a valid value, no carry
+                }
+                // else: try next value (continue inner loop)
+            }
+        }
+        true // all fields carried = done
+    }
+}
+
+impl Iterator for StructuralEnum {
+    type Item = Combination;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        // First iteration: use initial indices
+        // Build current values
+        let mut values: Vec<i64> = self
+            .indices
+            .iter()
+            .enumerate()
+            .map(|(i, &idx)| self.allowed[i][idx])
+            .collect();
+
+        // Advance to next combination
+        let carry = self.advance_indices(&mut values);
+        if carry {
+            self.done = true;
+        }
+
+        // Apply enable_mask / enable_set
+        let final_values = self.apply_enable_masks(&values);
+
+        let coordinates = Coordinates::new(final_values.clone());
+        let point = Point::new(coordinates.clone());
+        Some(Combination {
+            values: final_values,
+            coordinates,
+            point,
+        })
+    }
+}
+
+impl StructuralEnum {
+    fn apply_enable_masks(&self, values: &[i64]) -> Vec<i64> {
+        let mut result = values.to_vec();
+        for constraint in &self.constraints {
+            match constraint {
+                ConstraintSpec::EnableMask { field, value, disable } => {
+                    if let Some(trigger_axis) = self.field_names.iter().position(|n| n == field) {
+                        if result[trigger_axis] == *value {
+                            for f in disable {
+                                if let Some(axis) = self.field_names.iter().position(|n| n == f) {
+                                    result[axis] = 0;
+                                }
+                            }
+                        }
+                    }
+                }
+                ConstraintSpec::EnableSet { field, value, set } => {
+                    if let Some(trigger_axis) = self.field_names.iter().position(|n| n == field) {
+                        if result[trigger_axis] == *value {
+                            for assignment in set {
+                                if let Some(axis) = self.field_names.iter().position(|n| n == &assignment.field) {
+                                    result[axis] = assignment.value;
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        result
+    }
+
+    /// Total number of structurally valid combinations.
+    /// Returns None if the product overflows.
+    pub fn total_combinations(&self) -> Option<usize> {
+        let mut total: usize = 1;
+        for i in 0..self.allowed.len() {
+            total = total.checked_mul(self.allowed[i].len())?;
+        }
+        Some(total)
+    }
+}
+
 /// Lazy cartesian product iterator over field domains.
 ///
 /// Unlike `expand_all()`, this iterator does not pre-allocate a Vec.

--- a/src/verify/evaluate.rs
+++ b/src/verify/evaluate.rs
@@ -896,4 +896,34 @@ mod tests {
         );
         assert!(results.is_empty());
     }
+
+    #[test]
+    fn build_runtime_checks_excludes_structural() {
+        let (allowed, cross_maps) = crate::verify::compose::structural_filters(&make_spec(
+            BTreeMap::from([
+                ("a".into(), FieldSpec { range: Some((0, 7)), alignment: None, values: None }),
+                ("b".into(), FieldSpec { range: Some((0, 7)), alignment: None, values: None }),
+            ]),
+            vec![
+                ConstraintSpec::Eq { field_a: "a".into(), field_b: "b".into() },
+                ConstraintSpec::Oneof { field: "a".into(), values: vec![0, 2, 4, 6] },
+                ConstraintSpec::Bitmask { field: "b".into(), mask: 1, value: 0 },
+            ],
+            ProjectorSpec::Sum,
+        ));
+        let _ = (allowed, cross_maps);
+        let spec = make_spec(
+            BTreeMap::from([
+                ("a".into(), FieldSpec { range: Some((0, 7)), alignment: None, values: None }),
+                ("b".into(), FieldSpec { range: Some((0, 7)), alignment: None, values: None }),
+            ]),
+            vec![
+                ConstraintSpec::Eq { field_a: "a".into(), field_b: "b".into() },
+                ConstraintSpec::Oneof { field: "a".into(), values: vec![0, 2, 4, 6] },
+            ],
+            ProjectorSpec::Sum,
+        );
+        let runtime = build_runtime_checks(&spec, &ConstraintRegistry::default());
+        assert_eq!(runtime.len(), 1);
+    }
 }

--- a/src/verify/evaluate.rs
+++ b/src/verify/evaluate.rs
@@ -131,16 +131,23 @@ fn build_runtime_checks(
     registry: &ConstraintRegistry,
 ) -> Vec<Box<dyn Check>> {
     // Filter to runtime-required constraints before building
-    let runtime_specs: Vec<ConstraintSpec> = spec.constraints.iter().filter(|c| match c {
-        ConstraintSpec::Eq { .. }
-        | ConstraintSpec::Neq { .. }
-        | ConstraintSpec::Lt { .. }
-        | ConstraintSpec::Gt { .. }
-        | ConstraintSpec::Le { .. }
-        | ConstraintSpec::Ge { .. }
-        | ConstraintSpec::Even { .. } => true,
-        _ => false,
-    }).cloned().collect();
+    let runtime_specs: Vec<ConstraintSpec> = spec
+        .constraints
+        .iter()
+        .filter(|c| {
+            matches!(
+                c,
+                ConstraintSpec::Eq { .. }
+                    | ConstraintSpec::Neq { .. }
+                    | ConstraintSpec::Lt { .. }
+                    | ConstraintSpec::Gt { .. }
+                    | ConstraintSpec::Le { .. }
+                    | ConstraintSpec::Ge { .. }
+                    | ConstraintSpec::Even { .. }
+            )
+        })
+        .cloned()
+        .collect();
 
     registry
         .build_all(&runtime_specs, &spec.fields)

--- a/src/verify/evaluate.rs
+++ b/src/verify/evaluate.rs
@@ -901,25 +901,69 @@ mod tests {
     fn build_runtime_checks_excludes_structural() {
         let (allowed, cross_maps) = crate::verify::compose::structural_filters(&make_spec(
             BTreeMap::from([
-                ("a".into(), FieldSpec { range: Some((0, 7)), alignment: None, values: None }),
-                ("b".into(), FieldSpec { range: Some((0, 7)), alignment: None, values: None }),
+                (
+                    "a".into(),
+                    FieldSpec {
+                        range: Some((0, 7)),
+                        alignment: None,
+                        values: None,
+                    },
+                ),
+                (
+                    "b".into(),
+                    FieldSpec {
+                        range: Some((0, 7)),
+                        alignment: None,
+                        values: None,
+                    },
+                ),
             ]),
             vec![
-                ConstraintSpec::Eq { field_a: "a".into(), field_b: "b".into() },
-                ConstraintSpec::Oneof { field: "a".into(), values: vec![0, 2, 4, 6] },
-                ConstraintSpec::Bitmask { field: "b".into(), mask: 1, value: 0 },
+                ConstraintSpec::Eq {
+                    field_a: "a".into(),
+                    field_b: "b".into(),
+                },
+                ConstraintSpec::Oneof {
+                    field: "a".into(),
+                    values: vec![0, 2, 4, 6],
+                },
+                ConstraintSpec::Bitmask {
+                    field: "b".into(),
+                    mask: 1,
+                    value: 0,
+                },
             ],
             ProjectorSpec::Sum,
         ));
         let _ = (allowed, cross_maps);
         let spec = make_spec(
             BTreeMap::from([
-                ("a".into(), FieldSpec { range: Some((0, 7)), alignment: None, values: None }),
-                ("b".into(), FieldSpec { range: Some((0, 7)), alignment: None, values: None }),
+                (
+                    "a".into(),
+                    FieldSpec {
+                        range: Some((0, 7)),
+                        alignment: None,
+                        values: None,
+                    },
+                ),
+                (
+                    "b".into(),
+                    FieldSpec {
+                        range: Some((0, 7)),
+                        alignment: None,
+                        values: None,
+                    },
+                ),
             ]),
             vec![
-                ConstraintSpec::Eq { field_a: "a".into(), field_b: "b".into() },
-                ConstraintSpec::Oneof { field: "a".into(), values: vec![0, 2, 4, 6] },
+                ConstraintSpec::Eq {
+                    field_a: "a".into(),
+                    field_b: "b".into(),
+                },
+                ConstraintSpec::Oneof {
+                    field: "a".into(),
+                    values: vec![0, 2, 4, 6],
+                },
             ],
             ProjectorSpec::Sum,
         );

--- a/src/verify/evaluate.rs
+++ b/src/verify/evaluate.rs
@@ -3,7 +3,7 @@
 //! Uses pluggable checks resolved from registries.
 
 use crate::spec::{ConstraintSpec, VerificationSpec};
-use crate::verify::compose::{coords_to_coord_vec, Combination, EnumerateIter};
+use crate::verify::compose::{coords_to_coord_vec, Combination, StructuralEnum};
 use crate::verify::registry::{Check, ConstraintRegistry, ProjectorRegistry};
 
 /// Result of evaluating a single constraint combination.
@@ -95,57 +95,61 @@ pub fn evaluate_all(
 
 /// Validate all combinations into a DynCoordSpace.
 ///
-/// Only valid combinations are stored in the CoordSpace.
-/// Invalid combinations are structurally absent (vacant slots),
-/// detectable in 1.65 ns via DynCoordSpace lookup.
-///
-/// Uses EnumerateIter for O(1) memory iteration — no Vec allocation.
+/// Uses StructuralEnum to generate only structurally valid combinations.
+/// Runtime-only constraints (eq, neq, lt, gt, le, ge, even) are evaluated
+/// on the reduced set. Invalid combinations are structurally absent.
 pub fn validate_into_space(
     spec: &VerificationSpec,
     constraint_registry: &ConstraintRegistry,
 ) -> tagma_core::DynCoordSpace<()> {
     use tagma_core::DynCoordSpace;
 
-    let checks = constraint_registry.build_all(&spec.constraints, &spec.fields);
-    let field_list: Vec<&String> = spec.fields.keys().collect();
+    let runtime_checks = build_runtime_checks(spec, constraint_registry);
     let mut space: DynCoordSpace<()> = DynCoordSpace::new();
 
-    for combo in EnumerateIter::new(spec) {
-        let coords = &combo.coordinates;
-
-        // Check field domain validity
-        let mut valid = true;
-        for (axis, name) in field_list.iter().enumerate() {
-            if let Some(value) = coords.get_axis(axis) {
-                if !spec.fields.get(*name).unwrap().allows(value) {
-                    valid = false;
-                    break;
-                }
-            }
-        }
-        if !valid {
-            continue;
-        }
-
-        // Check all constraints
+    for combo in StructuralEnum::new(spec) {
         let mut passes = true;
-        for check in &checks {
+        for check in &runtime_checks {
             if !check.allows(combo.point.coordinates()) {
                 passes = false;
                 break;
             }
         }
-        if !passes {
-            continue;
-        }
-
-        // Valid: store in CoordSpace
-        if let Some(path) = coords_to_coord_vec(&coords.raw) {
-            let _ = space.place(&path, ());
+        if passes {
+            if let Some(path) = coords_to_coord_vec(&combo.coordinates.raw) {
+                let _ = space.place(&path, ());
+            }
         }
     }
 
     space
+}
+
+/// Build only runtime-evaluated checks, excluding structurally-enforced constraints.
+fn build_runtime_checks(
+    spec: &VerificationSpec,
+    registry: &ConstraintRegistry,
+) -> Vec<Box<dyn Check>> {
+    let runtime_types = ["eq", "neq", "lt", "gt", "le", "ge", "even"];
+    registry
+        .build_all(&spec.constraints, &spec.fields)
+        .into_iter()
+        .zip(spec.constraints.iter())
+        .filter(|(_, c)| {
+            let type_name = match c {
+                ConstraintSpec::Eq { .. } => "eq",
+                ConstraintSpec::Neq { .. } => "neq",
+                ConstraintSpec::Lt { .. } => "lt",
+                ConstraintSpec::Gt { .. } => "gt",
+                ConstraintSpec::Le { .. } => "le",
+                ConstraintSpec::Ge { .. } => "ge",
+                ConstraintSpec::Even { .. } => "even",
+                _ => "",
+            };
+            runtime_types.contains(&type_name)
+        })
+        .map(|(check, _)| check.into_check())
+        .collect()
 }
 
 fn describe_field(field_spec: &crate::spec::FieldSpec) -> String {

--- a/src/verify/evaluate.rs
+++ b/src/verify/evaluate.rs
@@ -130,25 +130,22 @@ fn build_runtime_checks(
     spec: &VerificationSpec,
     registry: &ConstraintRegistry,
 ) -> Vec<Box<dyn Check>> {
-    let runtime_types = ["eq", "neq", "lt", "gt", "le", "ge", "even"];
+    // Filter to runtime-required constraints before building
+    let runtime_specs: Vec<ConstraintSpec> = spec.constraints.iter().filter(|c| match c {
+        ConstraintSpec::Eq { .. }
+        | ConstraintSpec::Neq { .. }
+        | ConstraintSpec::Lt { .. }
+        | ConstraintSpec::Gt { .. }
+        | ConstraintSpec::Le { .. }
+        | ConstraintSpec::Ge { .. }
+        | ConstraintSpec::Even { .. } => true,
+        _ => false,
+    }).cloned().collect();
+
     registry
-        .build_all(&spec.constraints, &spec.fields)
+        .build_all(&runtime_specs, &spec.fields)
         .into_iter()
-        .zip(spec.constraints.iter())
-        .filter(|(_, c)| {
-            let type_name = match c {
-                ConstraintSpec::Eq { .. } => "eq",
-                ConstraintSpec::Neq { .. } => "neq",
-                ConstraintSpec::Lt { .. } => "lt",
-                ConstraintSpec::Gt { .. } => "gt",
-                ConstraintSpec::Le { .. } => "le",
-                ConstraintSpec::Ge { .. } => "ge",
-                ConstraintSpec::Even { .. } => "even",
-                _ => "",
-            };
-            runtime_types.contains(&type_name)
-        })
-        .map(|(check, _)| check.into_check())
+        .map(|check| check.into_check())
         .collect()
 }
 

--- a/src/verify/evaluate.rs
+++ b/src/verify/evaluate.rs
@@ -3,7 +3,7 @@
 //! Uses pluggable checks resolved from registries.
 
 use crate::spec::{ConstraintSpec, VerificationSpec};
-use crate::verify::compose::Combination;
+use crate::verify::compose::{coords_to_coord_vec, Combination, EnumerateIter};
 use crate::verify::registry::{Check, ConstraintRegistry, ProjectorRegistry};
 
 /// Result of evaluating a single constraint combination.
@@ -93,8 +93,63 @@ pub fn evaluate_all(
         .collect()
 }
 
-fn describe_field(fs: &crate::spec::FieldSpec) -> String {
-    if let Some(ref vals) = fs.values {
+/// Validate all combinations into a DynCoordSpace.
+///
+/// Only valid combinations are stored in the CoordSpace.
+/// Invalid combinations are structurally absent (vacant slots),
+/// detectable in 1.65 ns via DynCoordSpace lookup.
+///
+/// Uses EnumerateIter for O(1) memory iteration — no Vec allocation.
+pub fn validate_into_space(
+    spec: &VerificationSpec,
+    constraint_registry: &ConstraintRegistry,
+) -> tagma_core::DynCoordSpace<()> {
+    use tagma_core::DynCoordSpace;
+
+    let checks = constraint_registry.build_all(&spec.constraints, &spec.fields);
+    let field_list: Vec<&String> = spec.fields.keys().collect();
+    let mut space: DynCoordSpace<()> = DynCoordSpace::new();
+
+    for combo in EnumerateIter::new(spec) {
+        let coords = &combo.coordinates;
+
+        // Check field domain validity
+        let mut valid = true;
+        for (axis, name) in field_list.iter().enumerate() {
+            if let Some(value) = coords.get_axis(axis) {
+                if !spec.fields.get(*name).unwrap().allows(value) {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+        if !valid {
+            continue;
+        }
+
+        // Check all constraints
+        let mut passes = true;
+        for check in &checks {
+            if !check.allows(combo.point.coordinates()) {
+                passes = false;
+                break;
+            }
+        }
+        if !passes {
+            continue;
+        }
+
+        // Valid: store in CoordSpace
+        if let Some(path) = coords_to_coord_vec(&coords.raw) {
+            let _ = space.place(&path, ());
+        }
+    }
+
+    space
+}
+
+fn describe_field(field_spec: &crate::spec::FieldSpec) -> String {
+    if let Some(ref vals) = field_spec.values {
         format!(
             "{{{}}}",
             vals.iter()
@@ -102,8 +157,8 @@ fn describe_field(fs: &crate::spec::FieldSpec) -> String {
                 .collect::<Vec<_>>()
                 .join(", ")
         )
-    } else if let Some((min, max)) = fs.range {
-        let step = fs.alignment.unwrap_or(1);
+    } else if let Some((min, max)) = field_spec.range {
+        let step = field_spec.alignment.unwrap_or(1);
         if step == 1 {
             format!("{}..={}", min, max)
         } else {
@@ -693,6 +748,58 @@ mod tests {
                 _ => {}
             }
         }
+    }
+
+    #[test]
+    fn validate_into_space_matches_evaluate_all() {
+        // validate_into_space should produce the same valid set as evaluate_all
+        let mut fields = BTreeMap::new();
+        fields.insert(
+            "op".into(),
+            FieldSpec {
+                range: None,
+                alignment: None,
+                values: Some(vec![0, 1, 2]),
+            },
+        );
+        fields.insert(
+            "sub".into(),
+            FieldSpec {
+                range: None,
+                alignment: None,
+                values: Some(vec![0, 1, 2, 3]),
+            },
+        );
+        let mapping: std::collections::HashMap<i64, Vec<i64>> =
+            [(0, vec![0]), (1, vec![0, 1, 2])].into();
+        let spec = make_spec(
+            fields,
+            vec![ConstraintSpec::Cross {
+                field_a: "op".into(),
+                field_b: "sub".into(),
+                mapping,
+            }],
+            ProjectorSpec::Sum,
+        );
+
+        // Reference: evaluate_all with Vec
+        let combos = crate::verify::compose::expand_all(&spec).unwrap();
+        let results = evaluate_all(
+            &spec,
+            combos,
+            &ConstraintRegistry::default(),
+            &ProjectorRegistry::default(),
+        );
+        let valid_count_ref = results.iter().filter(|r| r.passed).count();
+
+        // CoordSpace: validate_into_space
+        let space = validate_into_space(&spec, &ConstraintRegistry::default());
+        let valid_count_cs = space.iter().count();
+
+        assert_eq!(
+            valid_count_cs, valid_count_ref,
+            "validate_into_space should match evaluate_all valid count"
+        );
     }
 
     // ── Edge cases ────────────────────────────────────────────────

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -153,7 +153,7 @@ fn verify_cva6_xif_mac_fixture() {
 }
 
 #[test]
-#[ignore = "medium: 2M combinations, ~25s on M1 Max (CI may timeout)"]
+#[ignore = "medium: 2M combos via CLI (old pipeline). Use release build or struct_enum for speed."]
 fn verify_cva6_xif_ref_r4_fixture() {
     let output = Command::new(env!("CARGO_BIN_EXE_ev"))
         .arg("verify")
@@ -219,7 +219,7 @@ fn synth_json_with_mock_backend() {
 }
 
 #[test]
-#[ignore = "slow: 33M combinations, run with -- --include-ignored (CI skips by default)"]
+#[ignore = "33M combos via CLI (old pipeline). struct_enum does it in ~200ms; pending CLI integration."]
 fn verify_cva6_xif_ref_fixture() {
     let output = Command::new(env!("CARGO_BIN_EXE_ev"))
         .arg("verify")


### PR DESCRIPTION
## Summary

Replace ev's `Vec<Combination>`-based domain expansion and evaluation pipeline with synTagma's structural coordinate space. `StructuralEnum` generates only structurally valid combinations by encoding constraints into the enumeration space itself, eliminating all runtime constraint evaluation for cross, oneof, range, and bitmask constraints.

Closes #40.

## Performance

| Fixture | Raw space | evaluate (old) | struct_enum (new) | Speedup |
|---------|:---------:|:--------------:|:-----------------:|:-------:|
| Small | 27 | 3.26 µs | 2.73 µs | 1.2x |
| Medium | 32,768 | 6.58 ms | 3.11 ms | 2.1x |
| Ibex RV32IMCB | 524,288 | 3.63 s | **49.5 ms** | **73x** |
| CVA6 XIF R4 | 2,097,152 | 1.43 s | **1.69 ms** | **846x** |
| CVA6 XIF full | 33,554,432 | ~32 s | **~32 ms** | **~1000x** |

## Changes

### Core: structural enumeration

- **`structural_filters()`**: Parse constraints (cross, oneof, range, bitmask) into per-field allowed values + cross-value mapping. Structural constraints are encoded into the enumeration space, requiring zero runtime evaluation.
- **`StructuralEnum`**: Iterator that generates only structurally valid combinations. Cross-constrained fields skip invalid values via an inner loop. Implements `Iterator<Item = Combination>`.
- **`coords_to_coord_vec()`**: Convert coordinate slice to `Vec<Coord>` for DynCoordSpace indexing.
- **`validate_into_space()`**: Uses StructuralEnum + runtime-only checks (eq, neq, lt, gt, le, ge, even) to build a `DynCoordSpace<()>` containing only valid combinations.
- **`build_runtime_checks()`**: Filters constraints to runtime-only types before building checks, avoiding unnecessary check construction.

### New constraint types (from PR #39, already merged)

- **`bitmask`**: `field & mask == value` — bit-level field conditions
- **`enable_set`**: Like `enable_mask` but sets fields to specified values

### Benchmark infrastructure

- `benches/bench.rs`: 24 benchmark functions across 4 fixture sizes, organized by speed class (coordspace ns-scale: sample_size=1000, expand ms-scale: 100, eval_light µs-ms: 100, eval_heavy seconds-scale: 10)
- `Cargo.toml`: `tagma-core` git dependency + `criterion` dev-dependency
- `run.sh`: structural enum benchmark integrated into CI pipeline

### Dependencies

```toml
tagma-core = { git = "https://github.com/ssccsorg/tagma", package = "tagma-core" }
```

Apache 2.0, no_std compatible, identical license to ev.

### Test coverage: 87 tests (73 lib + 14 CLI), 0 failed

| Area | Tests |
|------|-------|
| `coords_to_coord_vec` | basic, out-of-range, empty |
| `structural_filters` | oneof, bitmask, cross mapping |
| `StructuralEnum` | without cross, with oneof, cross matching |
| `build_runtime_checks` | excludes structural types |
| `validate_into_space` | matches evaluate_all valid count |
| constraint types | bitmask_constraint, expand_enable_set |
