### PR TITLE
PR: feat: make structural enumeration the CLI verify default #42

### DIFF
--- a/src/report/reporter.rs
+++ b/src/report/reporter.rs
@@ -224,9 +224,12 @@ impl ReporterCapable for TextReporter {
                 println!("Failures:");
                 for (i, e) in failed_rows.iter().enumerate() {
                     if i == MAX_PRINTED_FAILURES {
+                        // failed_count includes structurally absent combinations
+                        // in the structural pipeline; the remaining present
+                        // rows are the accurate unprinted detail.
                         println!(
                             "  ... and {} more failures",
-                            failed_count - MAX_PRINTED_FAILURES
+                            failed_rows.len() - MAX_PRINTED_FAILURES
                         );
                         break;
                     }

--- a/src/report/reporter.rs
+++ b/src/report/reporter.rs
@@ -38,6 +38,22 @@ pub trait ReporterCapable: Send + Sync {
 }
 
 // ============================================================================
+// Count helpers
+// ============================================================================
+
+/// Split an evaluation list into passed/failed counts against the raw total.
+/// The invariant passed <= total is enforced loudly: a silent usize wrap in
+/// release would corrupt verification counts.
+fn split_counts(total: usize, evaluations: &[Evaluation]) -> (usize, usize) {
+    let passed = evaluations.iter().filter(|e| e.passed).count();
+    assert!(
+        passed <= total,
+        "reporter invariant violated: passed ({passed}) exceeds raw total ({total})"
+    );
+    (passed, total - passed)
+}
+
+// ============================================================================
 // CSV Reporter
 // ============================================================================
 
@@ -52,8 +68,7 @@ impl ReporterCapable for CsvReporter {
         total: usize,
         evaluations: &[Evaluation],
     ) -> bool {
-        let passed_count = evaluations.iter().filter(|e| e.passed).count();
-        let failed_count = total - passed_count;
+        let (passed_count, failed_count) = split_counts(total, evaluations);
 
         // Print metadata as comments
         println!("# target: {}", target);
@@ -110,8 +125,7 @@ impl ReporterCapable for TraceReporter {
         total: usize,
         evaluations: &[Evaluation],
     ) -> bool {
-        let passed_count = evaluations.iter().filter(|e| e.passed).count();
-        let failed_count = total - passed_count;
+        let (passed_count, failed_count) = split_counts(total, evaluations);
         let started_at = chrono::Utc::now();
 
         println!(
@@ -192,8 +206,7 @@ impl ReporterCapable for TextReporter {
         total: usize,
         evaluations: &[Evaluation],
     ) -> bool {
-        let passed_count = evaluations.iter().filter(|e| e.passed).count();
-        let failed_count = total - passed_count;
+        let (passed_count, failed_count) = split_counts(total, evaluations);
 
         println!("target: {}", target);
         println!("total:  {}", total);
@@ -202,21 +215,23 @@ impl ReporterCapable for TextReporter {
         println!();
 
         if failed_count > 0 {
-            println!("Failures:");
-            // Cap the detail listing: the full list can be gigabytes for
-            // sparse spaces (e.g. 432K invalid rv32imcb encodings each
-            // carrying the cross-mapping description). The summary lines
-            // above remain authoritative; the cap keeps the log usable.
+            // The summary lines above are authoritative; the detail listing
+            // is capped (the full list can be gigabytes for sparse spaces).
             const MAX_PRINTED_FAILURES: usize = 25;
-            for (i, e) in evaluations.iter().filter(|e| !e.passed).enumerate() {
-                if i == MAX_PRINTED_FAILURES {
-                    println!(
-                        "  ... and {} more failures",
-                        failed_count - MAX_PRINTED_FAILURES
-                    );
-                    break;
+            let failed_rows: Vec<&Evaluation> =
+                evaluations.iter().filter(|e| !e.passed).collect();
+            if !failed_rows.is_empty() {
+                println!("Failures:");
+                for (i, e) in failed_rows.iter().enumerate() {
+                    if i == MAX_PRINTED_FAILURES {
+                        println!(
+                            "  ... and {} more failures",
+                            failed_count - MAX_PRINTED_FAILURES
+                        );
+                        break;
+                    }
+                    println!("  [FAIL] {:?} — {}", e.combination.values, e.reason);
                 }
-                println!("  [FAIL] {:?} — {}", e.combination.values, e.reason);
             }
         }
 
@@ -275,8 +290,7 @@ impl ReporterCapable for JsonReporter {
         total: usize,
         evaluations: &[Evaluation],
     ) -> bool {
-        let passed_count = evaluations.iter().filter(|e| e.passed).count();
-        let failed_count = total - passed_count;
+        let (passed_count, failed_count) = split_counts(total, evaluations);
         let origin = format!("ev/{}", env!("CARGO_PKG_VERSION"));
         let timestamp = chrono::Utc::now().to_rfc3339();
         let spec_hash = spec_hash.to_string();


### PR DESCRIPTION
## Summary

Integrates the structural enumeration pipeline (issue #40, tagma_core CoordSpace) into the `ev verify` CLI path, closing issue #42 and unlocking the two speed-ignored CLI tests.

## Changes

- `src/verify/compose.rs`: `raw_total_combinations` computes the cartesian product size from field domains without enumeration, sharing the overflow and `MAX_COMBINATIONS` guard with `expand_all`.
- `src/verify/evaluate.rs`: `evaluate_structural` returns the raw total plus the evaluations of the structurally valid subset (StructuralEnum + evaluate_all), with an invariant guard that fails loudly if the emitted count exceeds the raw total.
- `src/report/reporter.rs`: `ReporterCapable::report` gains a `total` parameter; the four reporters derive failed = total - passed via `split_counts`, which asserts passed <= total. The TextReporter prints the failure header only when failure rows are present.
- `src/main.rs`: `verify` routes through `evaluate_structural`; the simulate channel is unchanged.
- Tests: the two ignored CLI tests now run and assert summary counts (16,384 / 2,560 / 13,824 R4; 33,554,432 / 196,608 / 33,357,824 full). Three lib-level tests in `tests/structural_enum.rs` pin `evaluate_structural` against `expand_all` + `evaluate_all`, including an enable_mask differential test (alu_ext).
- `run.sh`: the 33M fixture is asserted in CI instead of skipped; CVA6 full and R4 counts checked via `_verify_check`.
- Docs: devlog `docs/devlog/2026-08-23-cli-structural-integration.md`, README pipeline and validation table updates.

## Measured result

| Metric | Before | After |
|---|---|---|
| `ev verify` CVA6 full (33.5M raw) | 10.4 s | 0.21 s |
| Evaluation rows for CVA6 full | 33,554,432 | 196,608 (valid subset) |
| CLI tests ignored for speed | 2 | 0 |

Counts are unchanged on every committed fixture (verified across all 10 fixtures). The 33M CLI test runs in 0.45 s in debug.

## Validation

- `cargo test --release`: 97 passing (73 lib + 16 CLI + 8 structural), none ignored.
- `bash run.sh --code`: fmt, clippy, build, test, bench all pass.

## Related

- Issue #42 (this PR), issue #40 (merged via PR #41).
- Note: overlaps `tests/cli_test.rs`, `run.sh`, and the README validation table with the PR for #47 (Tagma fixtures); the R4 test conflict resolves to this PR's version.